### PR TITLE
Add option to open a wand when dropping an item

### DIFF
--- a/src/main/java/com/elmakers/mine/bukkit/magic/listener/PlayerController.java
+++ b/src/main/java/com/elmakers/mine/bukkit/magic/listener/PlayerController.java
@@ -213,6 +213,7 @@ public class PlayerController implements Listener {
                         inventory.setHeldItemSlot(previouslySelected);
                     } else {
                         newWand.openInventory();
+                        newWand.setStoredSlot(previouslySelected);
                         break;
                     }
                 }

--- a/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
+++ b/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
@@ -258,6 +258,7 @@ public class Wand implements CostReducer, com.elmakers.mine.bukkit.api.wand.Wand
     public static byte HIDE_FLAGS = 60;
 
     private Inventory storedInventory = null;
+    private int storedSlot;
 
     private static final ItemStack[] itemTemplate = new ItemStack[0];
 
@@ -4600,6 +4601,7 @@ public class Wand implements CostReducer, com.elmakers.mine.bukkit.api.wand.Wand
         }
         storedInventory.setContents(contents);
         inventory.clear();
+        storedSlot = inventory.getHeldItemSlot();
 
         return true;
     }
@@ -4637,6 +4639,8 @@ public class Wand implements CostReducer, com.elmakers.mine.bukkit.api.wand.Wand
         inventory.setContents(storedInventory.getContents());
         storedInventory = null;
         saveItemState();
+
+        inventory.setHeldItemSlot(storedSlot);
 
         player.updateInventory();
 

--- a/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
+++ b/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
@@ -4571,6 +4571,10 @@ public class Wand implements CostReducer, com.elmakers.mine.bukkit.api.wand.Wand
         return remainder.size() == 0;
     }
 
+    public void setStoredSlot(int slot) {
+        this.storedSlot = slot;
+    }
+
     public boolean storeInventory() {
         if (storedInventory != null) {
             if (mage != null) {


### PR DESCRIPTION
When this option is enabled, when the player drops an item with Q, it will open the leftmost wand in the inventory. Effectively rebinding Q to "activate wand".
Dropping an item while sneaking and dropping an item by dragging will still work and are ignored by this option.