### PR TITLE
CustomProjectileAction Minimum Range Options

### DIFF
--- a/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
@@ -56,7 +56,7 @@ public class ChangeContextAction extends CompoundAction {
         sourceDirection = ConfigurationUtils.getVector(parameters, "source_direction");
         targetDirection = ConfigurationUtils.getVector(parameters, "target_direction");
         sourceDirectionOffset = ConfigurationUtils.getVector(parameters, "source_direction_offset");
-        targetDirectionOffset = ConfigurationUtils.getVector(parameters, "source_direction_offset");
+        targetDirectionOffset = ConfigurationUtils.getVector(parameters, "target_direction_offset");
         persistTarget = parameters.getBoolean("persist_target", false);
         attachBlock = parameters.getBoolean("target_attachment", false);
         snapTargetToSize = parameters.getInt("target_snap", 0);

--- a/src/main/java/com/elmakers/mine/bukkit/action/builtin/CustomProjectileAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/builtin/CustomProjectileAction.java
@@ -39,6 +39,9 @@ public class CustomProjectileAction extends CompoundAction
     private int lifetime;
     private int attachDuration;
     private int range;
+    private double min_range;
+    private double min_entity_range;
+    private double min_block_range;
     private double speed;
     private VectorTransform velocityTransform;
     private double spread;
@@ -208,6 +211,14 @@ public class CustomProjectileAction extends CompoundAction
         reverseDirection = parameters.getBoolean("reverse", false);
         startDistance = parameters.getInt("start", 0);
         range = parameters.getInt("range", 0);
+        min_entity_range = parameters.getDouble("min_entity_range",0);
+        min_block_range = parameters.getDouble("min_block_range",0);
+        min_range = parameters.getDouble("min_entity_range",Math.max(min_entity_range,min_block_range));
+        
+        if(min_range<Math.max(min_entity_range,min_block_range)) {
+        	min_range = Math.max(min_entity_range,min_block_range);
+        }
+        
         projectileEffectKey = parameters.getString("projectile_effects", "projectile");
         headshotEffectKey = parameters.getString("headshot_effects", "headshot");
         hitEffectKey = parameters.getString("hit_effects", "hit");
@@ -568,10 +579,60 @@ public class CustomProjectileAction extends CompoundAction
         Location targetLocation;
         Targeting.TargetingResult targetingResult = Targeting.TargetingResult.MISS;
         Target target = null;
+        
         if (!ignoreTargeting) {
             targeting.start(projectileLocation);
             target = targeting.target(actionContext, distanceTravelledThisTick);
             targetingResult = targeting.getResult();
+            targetLocation = target.getLocation();
+            
+            boolean keepGoing = distanceTravelled<min_range;
+            Location tempLocation = projectileLocation.clone();
+            int iter = 0;
+            
+            while(keepGoing)
+            {
+            	if(targetingResult == Targeting.TargetingResult.MISS) {
+            		keepGoing = false;
+            	}
+            	else if(targetingResult != null && targetLocation.distance(projectileLocation)+distanceTravelled >= min_range) {
+            		keepGoing = false;
+            	}
+            	else if(targetLocation.distance(projectileLocation)+distanceTravelled >= min_entity_range && targetingResult == Targeting.TargetingResult.ENTITY)
+            	{
+            		keepGoing = false;
+            	}
+            	else if(targetLocation.distance(projectileLocation)+distanceTravelled >= min_block_range && targetingResult == Targeting.TargetingResult.BLOCK)
+            	{
+            		keepGoing = false;
+            	}
+            	else if(targetLocation.distance(projectileLocation) >= distanceTravelledThisTick)
+            	{
+            		keepGoing = false;
+            	}
+            	else if(iter > 1000) {
+            		keepGoing = false;
+            	}
+            	else {
+            		
+            		if(tempLocation.distance(projectileLocation)<targetLocation.distance(projectileLocation)) {
+            			tempLocation.add(velocity.clone().multiply(targetLocation.distance(projectileLocation)+0.1));
+            		}
+            		else {
+            			tempLocation.add(velocity.clone().multiply(0.2));
+            		}
+            		
+                    actionContext.setTargetLocation(tempLocation);
+                    actionContext.setTargetEntity(null);
+                    actionContext.setDirection(velocity);
+            		
+                    targeting.start(tempLocation);
+                    target = targeting.target(actionContext, distanceTravelledThisTick-tempLocation.distance(projectileLocation));
+                    targetingResult = targeting.getResult();
+                    targetLocation = target.getLocation();
+                    iter++;
+            	}
+            }
         }
         if (targetingResult == Targeting.TargetingResult.MISS) {
             if (hasBlockMissEffects && target != null) {
@@ -649,8 +710,19 @@ public class CustomProjectileAction extends CompoundAction
         if (!block.getChunk().isLoaded()) {
             return miss();
         }
-
-        if (targetingResult == Targeting.TargetingResult.BLOCK) {
+        
+        if(distanceTravelled<min_range && targetingResult != null) {
+        	if(distanceTravelled>=min_block_range && targetingResult == Targeting.TargetingResult.BLOCK) {
+        		Bukkit.getConsoleSender().sendMessage(ChatColor.RED+ "hit a block");
+        		return miss();
+        	}
+        	
+        	if(distanceTravelled>=min_entity_range && targetingResult == Targeting.TargetingResult.ENTITY) {
+        		Bukkit.getConsoleSender().sendMessage(ChatColor.RED+ "hit an entity");
+        		return miss();
+        	}
+        }
+        else if (targetingResult == Targeting.TargetingResult.BLOCK) {
             return hitBlock(block);
         } else if (targetingResult == Targeting.TargetingResult.ENTITY) {
             entityHitCount++;

--- a/src/main/java/com/elmakers/mine/bukkit/action/builtin/CustomProjectileAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/builtin/CustomProjectileAction.java
@@ -713,12 +713,10 @@ public class CustomProjectileAction extends CompoundAction
         
         if(distanceTravelled<min_range && targetingResult != null) {
         	if(distanceTravelled>=min_block_range && targetingResult == Targeting.TargetingResult.BLOCK) {
-        		Bukkit.getConsoleSender().sendMessage(ChatColor.RED+ "hit a block");
         		return miss();
         	}
         	
         	if(distanceTravelled>=min_entity_range && targetingResult == Targeting.TargetingResult.ENTITY) {
-        		Bukkit.getConsoleSender().sendMessage(ChatColor.RED+ "hit an entity");
         		return miss();
         	}
         }


### PR DESCRIPTION
Added minimum range parameters for custom projectile spells (entities and/or blocks). This is useful if you want a projectile to travel a certain distance before it has an effect, but don't want it to be able to pass through certain things. Default values should have no effect on how spells currently behave.

Also fixed a small bug in the ChangeContextAction parameters.

Example Spell:

```
spear:
    icon: ink_sack:1
    icon_url: http://textures.minecraft.net/texture/543a93796b389fc710671b62106068619b7673e7bf48a6c77bc4db921d54
    category: combat
    worth: 100
    earns_sp: 6
    class: ActionSpell
    actions:
        cast:
        - class: ChangeContext
          actions:
          - class: CustomProjectile
            actions:
            - class: Damage
    effects:
        cast:
        -  class: EffectSingle
           sound: entity_player_attack_strong
           sound_volume: 0.2
           location: origin
        -  class: EffectSingle
           location: origin
           effectlib:
             class: LineEffect
             type: instant
             particle: cloud
             relativeOffset: 5.5,-.25,-.125
             length: 2
             duration: 0.25
        -  class: EffectSingle
           location: origin
           effectlib:
             class: LineEffect
             type: instant
             color: 663300
             particle: redstone
             relativeOffset: 0,-.25,-.125
             length: 5.5
        hit:
        -  class: EffectSingle
           sound: entity_player_attack_strong
           sound_volume: 1.2
           location: target
           particle: explosion_large
    parameters:
        relative_source_offset: 0,-.25,.4
        use_target_location: false
        target: other
        hitbox: true
        allow_max_range: true
        reorient: false
        target_type: Damageable
        player_damage: 3
        entity_damage: 6
        target_breakables: 2
        cooldown: 500
        speed: 10
        target_direction_speed: 2
        target_self_timeout: 2000
        min_entity_range: 5.5
        range: 8
    costs:
        mana: 30
```