### PR TITLE
Do not include outdated transitive dependencies of multiverse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
             <artifactId>Multiverse-Core</artifactId>
             <version>2.5</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.mewin</groupId>


### PR DESCRIPTION
As can see in the (partial) dependency tree below, `Multiverse-core` depends on a logging library that depends on a totally outdated version of `craftbukkit`. This is causing problems for everyone who does not have this library available when building magic. This PR stops maven from including any of `Multiverse-core`'s sub-dependencies effectively working around the issue.
 
```
[INFO] +- com.onarandombox.multiversecore:Multiverse-Core:jar:2.5:provided
[INFO] |  +- (org.bukkit:bukkit:jar:1.9-R0.1-SNAPSHOT:provided - version managed from 1.7.2-R0.2; omitted for duplicate)
[INFO] |  +- com.dumptruckman.minecraft:Logging:jar:1.0.9:provided
[INFO] |  |  +- org.bukkit:craftbukkit:jar:1.3.2-R0.2-SNAPSHOT:provided
```