### PR TITLE
PersistCaster add-on

### DIFF
--- a/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
@@ -158,6 +158,7 @@ public class ChangeContextAction extends CompoundAction {
         }
         if (relativeSourceOffset != null)
         {
+        	//If persistCaster is true, it makes the vector relative to the caster and not what the sourceLocation may be
             if (persistCaster) {
             	Vector offset = VectorUtils.rotateVector(relativeSourceOffset, context.getMage().getEyeLocation());
                 sourceLocation.add(offset);

--- a/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChangeContextAction.java
@@ -40,6 +40,7 @@ public class ChangeContextAction extends CompoundAction {
     private String sourceLocation;
     private boolean persistTarget;
     private boolean attachBlock;
+    private boolean persistCaster;
     private int snapTargetToSize;
     private int sourcePitchMin;
     private int sourcePitchMax;
@@ -67,6 +68,7 @@ public class ChangeContextAction extends CompoundAction {
         relativeTargetDirectionPitchOffset = (float)(parameters.getDouble("target_relative_direction_pitch_offset", 0));
         persistTarget = parameters.getBoolean("persist_target", false);
         attachBlock = parameters.getBoolean("target_attachment", false);
+        persistCaster = parameters.getBoolean("persist_caster", false);
         snapTargetToSize = parameters.getInt("target_snap", 0);
         targetLocation = parameters.getString("target_location");
         sourceLocation = parameters.getString("source_location");
@@ -156,8 +158,13 @@ public class ChangeContextAction extends CompoundAction {
         }
         if (relativeSourceOffset != null)
         {
-            Vector offset = VectorUtils.rotateVector(relativeSourceOffset, sourceLocation);
-            sourceLocation.add(offset);
+            if (persistCaster) {
+            	Vector offset = VectorUtils.rotateVector(relativeSourceOffset, context.getMage().getEyeLocation());
+                sourceLocation.add(offset);
+            } else {
+            	Vector offset = VectorUtils.rotateVector(relativeSourceOffset, sourceLocation);
+                sourceLocation.add(offset);
+            }
         }
         if (snapTargetToSize > 0 && targetLocation != null)
         {
@@ -177,8 +184,13 @@ public class ChangeContextAction extends CompoundAction {
         }
         if (relativeTargetOffset != null & targetLocation != null)
         {
-            Vector offset = VectorUtils.rotateVector(relativeTargetOffset, targetLocation);
-            targetLocation.add(offset);
+            if (persistCaster) {
+            	Vector offset = VectorUtils.rotateVector(relativeTargetOffset, context.getMage().getEyeLocation());
+                targetLocation.add(offset);
+            } else {
+            	Vector offset = VectorUtils.rotateVector(relativeTargetOffset, targetLocation);
+                targetLocation.add(offset);
+            }
         }
         if (randomSourceOffset != null)
         {


### PR DESCRIPTION
The param persistCaster will make all relative changes against the caster and not what sourceLocation or targetLocation may be. This is deal for spells that want to do fancier stuff while all in relative to the player.