### PR TITLE
Add error-prone warnings

### DIFF
--- a/CompatibilityLib/pom.xml
+++ b/CompatibilityLib/pom.xml
@@ -13,6 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<version.java>1.7</version.java>
 		<bukkit.version>1.9.2-R0.1-SNAPSHOT</bukkit.version>
+		<findbugs.version>1.3.9</findbugs.version>
 	</properties>
 
 	<dependencies>
@@ -21,6 +22,13 @@
 			<artifactId>bukkit</artifactId>
 			<version>${bukkit.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<!-- For Nullability annotations, provided by guava. -->
+		<dependency>
+		<groupId>com.google.code.findbugs</groupId>
+		<artifactId>jsr305</artifactId>
+		<version>${findbugs.version}</version>
+		<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/CompatibilityLib/src/main/java/com/elmakers/mine/bukkit/utility/NMSUtils.java
+++ b/CompatibilityLib/src/main/java/com/elmakers/mine/bukkit/utility/NMSUtils.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 /**
  * Contains some raw methods for doing some simple NMS utilities.
  * 
@@ -1330,6 +1332,7 @@ public class NMSUtils {
         return meta;
     }
 
+    @Nullable
     public static Boolean getMetaBoolean(Object node, String tag) {
         if (node == null || !class_NBTTagCompound.isInstance(node)) return null;
         Boolean meta = null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/ActionFactory.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/ActionFactory.java
@@ -1,5 +1,8 @@
 package com.elmakers.mine.bukkit.action;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.Maps;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -9,9 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ForwardingMap;
-import com.google.common.collect.Maps;
+import javax.annotation.Nullable;
 
 /**
  * Creates new action instances from a "class" parameter usually obtained from a
@@ -173,6 +174,7 @@ public class ActionFactory {
                 "%s",
         };
 
+        @Nullable
         @Override
         public ActionConstructor resolve(String className,
                 List<String> attempts) {
@@ -211,6 +213,7 @@ public class ActionFactory {
             return null;
         }
 
+        @Nullable
         private static ActionConstructor createConstructor(Class<?> clazz) {
             Constructor<?> constructor;
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/ActionHandler.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/ActionHandler.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public class ActionHandler implements com.elmakers.mine.bukkit.api.action.ActionHandler, Cloneable
 {
     private List<ActionContext> actions = new ArrayList<>();
@@ -25,7 +27,7 @@ public class ActionHandler implements com.elmakers.mine.bukkit.api.action.Action
     private boolean usesBrush = false;
     private boolean requiresBuildPermission = false;
     private boolean requiresBreakPermission = false;
-    private Integer currentAction = null;
+    private @Nullable Integer currentAction = null;
     private boolean started = false;
     private static String debugIndent = "";
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/BaseShopAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/BaseShopAction.java
@@ -723,6 +723,7 @@ public abstract class BaseShopAction extends BaseSpellAction implements GUIActio
         return formatItemAmount(controller, getWorthItem(controller), amount);
     }
 
+    @Nullable
     protected ItemStack getWorthItem(MageController controller) {
         return worthItem == null ? controller.getWorthItem() : worthItem;
     }
@@ -851,6 +852,7 @@ public abstract class BaseShopAction extends BaseSpellAction implements GUIActio
         return showItems(context, items);
     }
 
+    @Nullable
     protected abstract List<ShopItem> getItems(CastContext context);
 
     protected @Nonnull CasterProperties getCaster(CastContext context) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/BaseSpellAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/BaseSpellAction.java
@@ -10,6 +10,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import java.util.Arrays;
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 public abstract class BaseSpellAction implements SpellAction
 {
     private boolean requiresTarget;
@@ -105,6 +107,7 @@ public abstract class BaseSpellAction implements SpellAction
     }
 
     @Override
+    @Nullable
     public Object clone()
     {
         try

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
@@ -54,10 +54,10 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
 
     private final Location location;
     private final Entity entity;
-    private Location targetLocation;
-    private Location targetSourceLocation;
-    private Location targetCenterLocation;
-    private Entity targetEntity;
+    private @Nullable Location targetLocation;
+    private @Nullable Location targetSourceLocation;
+    private @Nullable Location targetCenterLocation;
+    private @Nullable Entity targetEntity;
     private UndoList undoList;
     private String targetName = null;
     private SpellResult result = SpellResult.NO_ACTION;
@@ -194,6 +194,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         }
     }
 
+    @Nullable
     @Override
     public Location getCastLocation() {
         if (location != null) {
@@ -209,6 +210,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return castLocation;
     }
 
+    @Nullable
     @Override
     public Location getWandLocation() {
         return getCastLocation();
@@ -238,12 +240,14 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return spell.getEntity();
     }
 
+    @Nullable
     @Override
     public LivingEntity getLivingEntity() {
         Entity entity = getEntity();
         return entity instanceof LivingEntity ? (LivingEntity)entity : null;
     }
 
+    @Nullable
     @Override
     public Location getLocation() {
         if (location != null) {
@@ -255,21 +259,25 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return spell.getLocation();
     }
 
+    @Nullable
     @Override
     public Location getTargetLocation() {
         return targetLocation;
     }
 
+    @Nullable
     @Override
     public Location getTargetSourceLocation() {
         return targetSourceLocation == null ? targetLocation : targetSourceLocation;
     }
 
+    @Nullable
     @Override
     public Block getTargetBlock() {
         return targetLocation == null ? null : targetLocation.getBlock();
     }
 
+    @Nullable
     @Override
     public Entity getTargetEntity() {
         return targetEntity;
@@ -296,6 +304,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         this.direction = direction;
     }
 
+    @Nullable
     @Override
     public World getWorld() {
         Location location = getLocation();
@@ -322,13 +331,15 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return spell;
     }
 
+    @Nullable
     @Override
     public Mage getMage() {
         return this.mage;
     }
 
+    @Nullable
     @Override
-    public @Nullable MageClass getMageClass() {
+    public MageClass getMageClass() {
         return this.mageClass;
     }
 
@@ -345,6 +356,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return mage.getActiveProperties();
     }
 
+    @Nullable
     @Override
     public MageController getController() {
         Mage mage = getMage();
@@ -451,9 +463,9 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         }
     }
 
+    @Nullable
     @Override
-    public Block getPreviousBlock()
-    {
+    public Block getPreviousBlock() {
         return targetingSpell != null ? targetingSpell.getPreviousBlock() : null;
     }
 
@@ -542,6 +554,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return effects;
     }
 
+    @Nullable
     public Color getEffectColor() {
         Color color = wand == null ? null : wand.getEffectColor();
         if (color == null) {
@@ -550,6 +563,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return color;
     }
 
+    @Nullable
     public String getEffectParticle() {
         String particle = wand == null ? null : wand.getEffectParticleName();
         if (particle == null) {
@@ -635,11 +649,13 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return baseSpell != null ? baseSpell.getMessage(key, def) : def;
     }
 
+    @Nullable
     @Override
     public Location findPlaceToStand(Location target, int verticalSearchDistance, boolean goUp) {
         return baseSpell != null ? baseSpell.findPlaceToStand(target, goUp, verticalSearchDistance) : location;
     }
 
+    @Nullable
     @Override
     public Location findPlaceToStand(Location targetLoc, int verticalSearchDistance) {
         return baseSpell != null ? baseSpell.findPlaceToStand(targetLoc, verticalSearchDistance, verticalSearchDistance) : location;
@@ -896,6 +912,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return targetingSpell == null ? true : targetingSpell.canTarget(entity, targetType);
     }
 
+    @Nullable
     @Override
     public MaterialBrush getBrush() {
         if (brush != null) {
@@ -956,6 +973,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return message;
     }
 
+    @Nullable
     @Override
     public Block getInteractBlock() {
         Location location = getEyeLocation();
@@ -1075,9 +1093,9 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return base;
     }
 
+    @Nullable
     @Override
-    public Location getTargetCenterLocation()
-    {
+    public Location getTargetCenterLocation() {
         return targetCenterLocation == null ? targetLocation : targetCenterLocation;
     }
 
@@ -1096,6 +1114,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return currentEffects;
     }
 
+    @Nullable
     @Override
     public Plugin getPlugin() {
         MageController controller = getController();
@@ -1160,6 +1179,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         }
     }
 
+    @Nullable
     @Override
     @Deprecated
     public Set<Material> getMaterialSet(String key) {
@@ -1202,6 +1222,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return com.elmakers.mine.bukkit.block.UndoList.getRegistry().isBreakable(block);
     }
 
+    @Nullable
     @Override
     public Double getBreakable(Block block) {
         return com.elmakers.mine.bukkit.block.UndoList.getRegistry().getBreakable(block);
@@ -1226,6 +1247,7 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
         return com.elmakers.mine.bukkit.block.UndoList.getRegistry().isReflective(block);
     }
 
+    @Nullable
     @Override
     public Double getReflective(Block block) {
         if (block == null) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/CompoundAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/CompoundAction.java
@@ -5,6 +5,8 @@ import com.elmakers.mine.bukkit.api.action.SpellAction;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.google.common.base.Preconditions;
+
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
@@ -13,6 +15,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 public abstract class CompoundAction extends BaseSpellAction
 {
     private boolean usesBrush = false;
@@ -20,11 +24,11 @@ public abstract class CompoundAction extends BaseSpellAction
     private boolean requiresBuildPermission = false;
     private boolean requiresBreakPermission = false;
     private boolean stopOnSuccess = false;
-    protected ConfigurationSection actionConfiguration;
-    protected CastContext actionContext;
+    protected @Nullable ConfigurationSection actionConfiguration;
+    protected @Nullable CastContext actionContext;
 
     protected Map<String, ActionHandler> handlers = new HashMap<>();
-    protected String currentHandler = null;
+    protected @Nullable String currentHandler = null;
     protected State state = State.NOT_STARTED;
 
     protected enum State {
@@ -50,6 +54,8 @@ public abstract class CompoundAction extends BaseSpellAction
     }
 
     protected SpellResult startActions(String handlerKey) {
+        Preconditions.checkState(actionContext != null);
+
         currentHandler = handlerKey;
         ActionHandler handler = handlers.get(currentHandler);
         if (handler != null) {
@@ -150,10 +156,12 @@ public abstract class CompoundAction extends BaseSpellAction
         addHandler(spell, "actions");
     }
 
+    @Nullable
     protected ActionHandler getHandler(String handlerKey) {
         return handlers.get(handlerKey);
     }
 
+    @Nullable
     protected ActionHandler addHandler(Spell spell, String handlerKey) {
         ActionHandler handler = handlers.get(handlerKey);
         if (handler != null) {
@@ -316,6 +324,7 @@ public abstract class CompoundAction extends BaseSpellAction
     }
 
     @Override
+    @Nullable
     public Object clone()
     {
         CompoundAction action = (CompoundAction)super.clone();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/CompoundEntityAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/CompoundEntityAction.java
@@ -2,12 +2,12 @@ package com.elmakers.mine.bukkit.action;
 
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 
 public abstract class CompoundEntityAction extends CompoundAction
 {
@@ -60,9 +60,9 @@ public abstract class CompoundEntityAction extends CompoundAction
         return SpellResult.NO_ACTION;
     }
 
+    @Nullable
     @Override
-    public Object clone()
-    {
+    public Object clone() {
         CompoundEntityAction action = (CompoundEntityAction)super.clone();
         if (action != null) {
             action.entities = new ArrayList<>(this.entities);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ItemShopAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ItemShopAction.java
@@ -7,16 +7,16 @@ import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import de.slikey.effectlib.util.ConfigUtils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 public class ItemShopAction extends BaseShopAction
 {
@@ -86,17 +86,17 @@ public class ItemShopAction extends BaseShopAction
         }
     }
 
-    protected ShopItem createShopItem(MageController controller, String itemKey, double worth) {
+    @Nullable protected ShopItem createShopItem(MageController controller, String itemKey, double worth) {
         ItemStack item = parseItemKey(controller, itemKey);
         return item == null ? null : new ShopItem(controller, item, worth);
     }
 
-    protected ShopItem createShopItem(MageController controller, ConfigurationSection configuration) {
+    @Nullable protected ShopItem createShopItem(MageController controller, ConfigurationSection configuration) {
         ItemStack item = parseItemKey(controller, configuration.getString("item"));
         return item == null ? null : new ShopItem(controller, item, configuration);
     }
 
-    protected ItemStack parseItemKey(MageController controller, String itemKey) {
+    @Nullable protected ItemStack parseItemKey(MageController controller, String itemKey) {
         if (itemKey == null || itemKey.isEmpty() || itemKey.equalsIgnoreCase("none"))
         {
             return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ProjectileAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ProjectileAction.java
@@ -20,10 +20,10 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
+
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+
 import java.util.Random;
 
 public class ProjectileAction  extends BaseProjectileAction

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RecallAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RecallAction.java
@@ -13,6 +13,19 @@ import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.elmakers.mine.bukkit.utility.SkinUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -28,19 +41,6 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Level;
 
 public class RecallAction extends BaseTeleportAction implements GUIAction
 {
@@ -658,7 +658,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
         return SpellResult.CAST;
 	}
 
-    protected Waypoint getUnknownWarp(String warpKey) {
+    @Nullable protected Waypoint getUnknownWarp(String warpKey) {
         MageController controller = context.getController();
         Location warpLocation = controller.getWarp(warpKey);
         if (warpLocation == null || warpLocation.getWorld() == null) {
@@ -696,7 +696,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
         context.getMage().activateGUI(this, displayInventory);
     }
 
-    protected Waypoint getFriend(String uuid)
+    @Nullable protected Waypoint getFriend(String uuid)
     {
         Player onlinePlayer = Bukkit.getPlayer(UUID.fromString(uuid));
         if (onlinePlayer == null) return null;
@@ -710,7 +710,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
         return new Waypoint(RecallType.WARP, onlinePlayer.getLocation(), title, castMessage, failMessage, "", null, iconURL);
     }
 
-    protected Waypoint getWarp(String warpKey)
+    @Nullable protected Waypoint getWarp(String warpKey)
     {
         if (warps == null) return getUnknownWarp(warpKey);
         ConfigurationSection config = warps.get(warpKey);
@@ -738,7 +738,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
         return new Waypoint(RecallType.WARP, warpLocation, title, castMessage, failMessage, description, icon, iconURL);
     }
 
-    protected Waypoint getCommand(CastContext context, String commandKey)
+    @Nullable protected Waypoint getCommand(CastContext context, String commandKey)
     {
         if (commands == null) return null;
         ConfigurationSection config = commands.get(commandKey);
@@ -757,7 +757,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
         return new Waypoint(RecallType.COMMAND, command, op, console, title, castMessage, failMessage, description, icon, iconURL);
     }
 
-	protected Waypoint getWaypoint(Player player, RecallType type, int index, ConfigurationSection parameters, CastContext context) {
+	@Nullable protected Waypoint getWaypoint(Player player, RecallType type, int index, ConfigurationSection parameters, CastContext context) {
 		Mage mage = context.getMage();
         MageController controller = context.getController();
 		switch (type) {
@@ -788,7 +788,7 @@ public class RecallAction extends BaseTeleportAction implements GUIAction
 		}
 	}
     
-    protected MaterialAndData getIcon(CastContext context, ConfigurationSection parameters, String key)
+    @Nullable protected MaterialAndData getIcon(CastContext context, ConfigurationSection parameters, String key)
     {
         String iconKey = parameters.getString(key);
         if (iconKey == null || iconKey.isEmpty()) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RecurseAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RecurseAction.java
@@ -9,10 +9,6 @@ import com.elmakers.mine.bukkit.block.BlockFace;
 import com.elmakers.mine.bukkit.block.MaterialAndData;
 import com.elmakers.mine.bukkit.spell.BaseSpell;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.configuration.ConfigurationSection;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,6 +17,10 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.ConfigurationSection;
 
 public class RecurseAction extends CompoundAction {
     protected int recursionDepth;
@@ -79,7 +79,7 @@ public class RecurseAction extends CompoundAction {
         BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST
     );
 
-    protected BlockFace getBlockFace(String name) {
+    @Nullable protected BlockFace getBlockFace(String name) {
         try {
             return BlockFace.valueOf(name.toUpperCase());
         } catch (Exception ex) {
@@ -87,7 +87,7 @@ public class RecurseAction extends CompoundAction {
         return null;
     }
 
-    protected List<BlockFace> getDirections(String name) {
+    @Nullable protected List<BlockFace> getDirections(String name) {
         if (name == null) {
             return null;
         }
@@ -107,7 +107,7 @@ public class RecurseAction extends CompoundAction {
         return singleSet;
     }
 
-    protected List<BlockFace> getDirections(ConfigurationSection parameters, String key) {
+    @Nullable protected List<BlockFace> getDirections(ConfigurationSection parameters, String key) {
         if (parameters.isString(key)) {
             String name = parameters.getString(key);
             return getDirections(name);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RideEntityAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/RideEntityAction.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public class RideEntityAction extends BaseSpellAction
 {
     private double moveDistance = 0;
@@ -395,6 +397,7 @@ public class RideEntityAction extends BaseSpellAction
         }
     }
 
+    @Nullable
     protected Entity getMount(CastContext context) {
         return isPassenger ? context.getEntity() : mount;
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SelectorAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SelectorAction.java
@@ -221,7 +221,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
             }
         }
 
-        protected List<Cost> parseCosts(ConfigurationSection node) {
+        @Nullable protected List<Cost> parseCosts(ConfigurationSection node) {
             if (node == null) {
                 return null;
             }
@@ -234,7 +234,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
             return costs;
         }
 
-        protected List<CostModifier> parseCostModifiers(ConfigurationSection configuration, String section) {
+        @Nullable protected List<CostModifier> parseCostModifiers(ConfigurationSection configuration, String section) {
             Collection<ConfigurationSection> modifierConfigs = ConfigurationUtils.getNodeList(configuration, section);
             if (modifierConfigs == null) {
                 return null;
@@ -496,7 +496,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
             }
         }
 
-        protected Cost takeCosts(CostReducer reducer, CastContext context) {
+        @Nullable protected Cost takeCosts(CostReducer reducer, CastContext context) {
             Cost required = getRequiredCost(reducer, context);
             if (required != null) {
                 return required;
@@ -510,7 +510,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
             return null;
         }
 
-        public Cost getRequiredCost(CostReducer reducer, CastContext context) {
+        @Nullable public Cost getRequiredCost(CostReducer reducer, CastContext context) {
             if (costs != null) {
                 for (Cost cost : costs) {
                     if (!cost.has(context.getMage(), context.getWand(), reducer)) {
@@ -636,7 +636,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
             return unavailable;
         }
 
-        public ItemStack getIcon() {
+        @Nullable public ItemStack getIcon() {
             return icon;
         }
 
@@ -947,7 +947,7 @@ public class SelectorAction extends BaseSpellAction implements GUIAction, CostRe
         return showItems(context);
     }
 
-    protected ItemStack parseItem(String itemKey) {
+    @Nullable protected ItemStack parseItem(String itemKey) {
         if (itemKey == null || itemKey.isEmpty() || itemKey.equalsIgnoreCase("none"))
         {
             return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SkillSelectorAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SkillSelectorAction.java
@@ -17,6 +17,12 @@ import com.elmakers.mine.bukkit.magic.MagicController;
 import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.elmakers.mine.bukkit.wand.Wand;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
@@ -24,13 +30,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import javax.annotation.Nonnull;
 
 public class SkillSelectorAction extends BaseSpellAction implements GUIAction {
     private int page;
@@ -125,6 +124,7 @@ public class SkillSelectorAction extends BaseSpellAction implements GUIAction {
             skillLevel = heroes.getSkillLevel(player, heroesSkill);
         }
 
+        @Nullable
         public String getSkillKey() {
             String key = getSpellKey();
             if (key != null) {
@@ -133,6 +133,7 @@ public class SkillSelectorAction extends BaseSpellAction implements GUIAction {
             return key;
         }
 
+        @Nullable
         public String getSpellKey() {
             if (heroesSkill != null) {
                 return "heroes*" + heroesSkill;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SpellShopAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/SpellShopAction.java
@@ -8,19 +8,13 @@ import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.magic.ProgressionPath;
 import com.elmakers.mine.bukkit.api.requirements.Requirement;
 import com.elmakers.mine.bukkit.api.spell.MageSpell;
-import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.PrerequisiteSpell;
+import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.spell.BaseSpell;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
-import org.apache.commons.lang.StringUtils;
-import org.bukkit.ChatColor;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,6 +23,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class SpellShopAction extends BaseShopAction
 {
@@ -85,6 +85,7 @@ public class SpellShopAction extends BaseShopAction
         }
     }
 
+    @Nullable
     @Override
     public List<ShopItem> getItems(CastContext context) {
         Mage mage = context.getMage();
@@ -200,7 +201,7 @@ public class SpellShopAction extends BaseShopAction
         return shopItems;
 	}
 
-    private ShopItem createShopItem(String key, Double worth, CastContext context) {
+    @Nullable private ShopItem createShopItem(String key, Double worth, CastContext context) {
         CasterProperties caster = getCaster(context);
         Mage mage = context.getMage();
         MageController controller = context.getController();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/batch/FillBatch.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/batch/FillBatch.java
@@ -9,14 +9,12 @@ import org.bukkit.entity.FallingBlock;
 import org.bukkit.inventory.ItemStack;
 
 import com.elmakers.mine.bukkit.api.block.MaterialBrush;
-import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.block.BoundingBox;
 import com.elmakers.mine.bukkit.spell.BrushSpell;
 
 public class FillBatch extends BrushBatch {
 	private final MaterialBrush brush;
 	private final World world;
-	private final Mage mage;
 
 	private final int absx;
 	private final int absy;
@@ -42,7 +40,6 @@ public class FillBatch extends BrushBatch {
 		super(spell);
 		this.bounds = new BoundingBox(p1.toVector(), p2.toVector());
 		this.brush = brush;
-		this.mage = spell.getMage();
 		this.world = p1.getWorld();
 		
 		int deltax = p2.getBlockX() - p1.getBlockX();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/BlockData.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/BlockData.java
@@ -1,6 +1,12 @@
 package com.elmakers.mine.bukkit.block;
 
 import com.elmakers.mine.bukkit.api.block.ModifyType;
+import com.elmakers.mine.bukkit.api.block.UndoList;
+import com.elmakers.mine.bukkit.api.magic.MaterialSet;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+import java.lang.ref.WeakReference;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -11,12 +17,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.util.BlockVector;
-import com.elmakers.mine.bukkit.api.block.UndoList;
-import com.elmakers.mine.bukkit.api.magic.MaterialSet;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-
-import java.lang.ref.WeakReference;
-import java.util.Set;
 
 /**
  * Stores a cached Block. Stores the coordinates and world, but will look up a block reference on demand.
@@ -231,7 +231,7 @@ public class BlockData extends MaterialAndData implements com.elmakers.mine.bukk
         return location.getBlockX() + "," + location.getBlockY() + "," + location.getBlockZ() + "," + worldName + "|" + getMaterial().getId() + ":" + getData();
     }
 
-    @SuppressWarnings("deprecation")
+    @Nullable @SuppressWarnings("deprecation")
     public static BlockData fromString(String s) {
         BlockData result = null;
         if (s == null) return null;
@@ -293,16 +293,16 @@ public class BlockData extends MaterialAndData implements com.elmakers.mine.bukk
         return location;
     }
 
+    @Nullable
     @Override
-    public World getWorld()
-    {
+    public World getWorld() {
         if (worldName == null || worldName.length() == 0) return null;
         return Bukkit.getWorld(worldName);
     }
 
+    @Nullable
     @Override
-    public Block getBlock()
-    {
+    public Block getBlock() {
         Block block = null;
         if (location != null)
         {
@@ -320,6 +320,7 @@ public class BlockData extends MaterialAndData implements com.elmakers.mine.bukk
         return isDifferent(getBlock());
     }
 
+    @Nullable
     @Override
     public UndoList getUndoList() {
         return undoList != null ? undoList.get() : null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/BlockList.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/BlockList.java
@@ -8,6 +8,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.util.BlockVector;
@@ -18,7 +20,7 @@ import com.elmakers.mine.bukkit.api.block.BlockData;
 public class BlockList implements com.elmakers.mine.bukkit.api.block.BlockList {
 
     protected BoundingBox          		area;
-    protected String					worldName;
+    protected @Nullable String          worldName;
 
     protected LinkedList<BlockData> 	blockList;
     protected HashSet<Long>        		blockIdMap;
@@ -269,6 +271,7 @@ public class BlockList implements com.elmakers.mine.bukkit.api.block.BlockList {
         }
     }
 
+    @Nullable
     public BlockData get(int index)
     {
         if (blockList == null || index >= blockList.size())
@@ -279,20 +282,20 @@ public class BlockList implements com.elmakers.mine.bukkit.api.block.BlockList {
     }
 
     @Override
-    public Object[] toArray()
-    {
-        if (blockList == null)
-        {
+    @Nullable
+    public Object[] toArray() {
+        if (blockList == null) {
+            // FIXME: This breaks the contract of Collection
             return null;
         }
         return blockList.toArray();
     }
 
     @Override
-    public <T> T[] toArray(T[] arg0)
-    {
-        if (blockList == null)
-        {
+    @Nullable
+    public <T> T[] toArray(T[] arg0) {
+        if (blockList == null) {
+            // FIXME: This breaks the contract of Collection
             return null;
         }
         return blockList.toArray(arg0);
@@ -324,6 +327,7 @@ public class BlockList implements com.elmakers.mine.bukkit.api.block.BlockList {
     }
 
     @Override
+    @Nullable
     public String getWorldName() {
         return worldName;
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/BoundingBox.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/BoundingBox.java
@@ -1,12 +1,13 @@
 package com.elmakers.mine.bukkit.block;
 
 import java.util.List;
+
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 
@@ -18,15 +19,17 @@ import com.elmakers.mine.bukkit.api.magic.MaterialSet;
 public class BoundingBox implements com.elmakers.mine.bukkit.api.block.BoundingBox
 {	
     protected static final Vector UNIT_VECTOR = new Vector(1, 1, 1);
-    protected BlockVector max;
-    protected BlockVector min;
+    protected @Nonnull BlockVector max;
+    protected @Nonnull BlockVector min;
 
     /**
      * Default constructor, used by Persistence to initialize instances.
+     * 
+     * @deprecated Persistence use only.
      */
-    public BoundingBox()
-    {
-
+    @SuppressWarnings("null")
+    @Deprecated
+    public BoundingBox() {
     }
 
     public BoundingBox(Vector p1, Vector p2)
@@ -71,21 +74,6 @@ public class BoundingBox implements com.elmakers.mine.bukkit.api.block.BoundingB
     {
         min = new BlockVector(Math.min(minX, maxX), Math.min(minY, maxY), Math.min(minZ, maxZ));
         max = new BlockVector(Math.max(minX, maxX), Math.max(minY, maxY), Math.max(minZ, maxZ));
-    }
-
-    /**
-     * TODO : Returns a copy of this BoundingBox, centerd around the target
-     * point
-     *
-     * @param newCenter
-     *            The new center for this BB
-     * @return A new BoundingBox representing this BB translated to newCenter
-     */
-    public BoundingBox centered(Vector newCenter)
-    {
-        // TODO
-        // BlockVector currentCenter = getCenter();
-        return this;
     }
 
     /**
@@ -271,64 +259,6 @@ public class BoundingBox implements com.elmakers.mine.bukkit.api.block.BoundingB
     }
 
     /**
-     * Return a (width 1) "face" of this BoundingBox.
-     *
-     * A "face" represents the side of this BB as given by "face".
-     *
-     * This can be used for defining a wall, floor, or ceiling for a volume.
-     *
-     * @param face
-     *            The BlockFace used to represent the face of this BB we want
-     * @return A new BB representing the specified face of the current BB
-     * @see #getFace(BlockFace, int, int)
-     */
-    public BoundingBox getFace(BlockFace face)
-    {
-        return getFace(face, 1, 0);
-    }
-
-    /**
-     * Return a "face" of a BoundingBox
-     *
-     * A "face" represents the side of this BB as given by "face".
-     *
-     * This can be used for defining a wall, floor, or ceiling for a volume.
-     *
-     * @param face
-     *            face The BlockFace used to represent the face of this BB we
-     *            want
-     * @param thickness
-     *            How thick to make the new BB
-     * @param offset
-     *            The offset (from the outside of this BB) to move the resultant
-     *            BB
-     * @return A new BB representing the specified face of the current BB, at
-     *         the specified offset and with the specified thickness
-     * @see #getFace(BlockFace)
-     */
-    public BoundingBox getFace(BlockFace face, int thickness, int offset)
-    {
-        // Brute-force this for now. There's probably a Matrix-y way to do this!
-        switch (face)
-        {
-        case UP:
-            return new BoundingBox(min.getBlockX(), max.getBlockY() + offset, min.getBlockZ(), max.getBlockX(), max.getBlockY() + offset + thickness, max.getBlockZ());
-        case DOWN:
-            return new BoundingBox(min.getBlockX(), min.getBlockY() - offset - thickness, min.getBlockZ(), max.getBlockX(), min.getBlockY() - offset, max.getBlockZ());
-        case WEST:
-            return new BoundingBox(min.getBlockX(), min.getBlockY(), max.getBlockZ() + offset, max.getBlockX(), max.getBlockY(), max.getBlockZ() + offset + thickness);
-        case EAST:
-            return new BoundingBox(min.getBlockX(), min.getBlockY(), min.getBlockZ() - offset - thickness, max.getBlockX(), max.getBlockY(), min.getBlockZ() - offset);
-        case SOUTH:
-            return new BoundingBox(max.getBlockX() + offset, min.getBlockY(), min.getBlockZ(), max.getBlockX() + offset + thickness, max.getBlockY(), max.getBlockZ());
-        case NORTH:
-            return new BoundingBox(min.getBlockX() - offset - thickness, min.getBlockY(), min.getBlockZ(), min.getBlockX() - offset, max.getBlockY(), max.getBlockZ());
-        default:
-            return null;
-        }
-    }
-
-    /**
      * Retrieve the maximum corner of this BoundingBox
      *
      * @return The maximum corner
@@ -381,26 +311,6 @@ public class BoundingBox implements com.elmakers.mine.bukkit.api.block.BoundingB
     }
 
     /**
-     * TODO: Scale this BB by the specified amount
-     *
-     * @param scale
-     *            The percent amount to scale this BB
-     * @return A new BB, representing this BB scaled by scale
-     */
-    public BoundingBox scale(double scale)
-    {
-        /*
-         * minY = 0; maxY = 128; minX = location.getBlockX() -
-         * PortalArea.defaultSize * ratio / 2; maxX = location.getBlockX() +
-         * PortalArea.defaultSize * ratio / 2; minZ = location.getBlockZ() -
-         * PortalArea.defaultSize * ratio / 2; maxZ = location.getBlockZ() +
-         * PortalArea.defaultSize * ratio / 2;.
-         */
-
-        return new BoundingBox(min, max);
-    }
-
-    /**
      * Set the maximum corner of this BoundingBox
      *
      * @param max
@@ -421,18 +331,4 @@ public class BoundingBox implements com.elmakers.mine.bukkit.api.block.BoundingB
     {
         this.min = min;
     }
-
-    /**
-     * Translate this bounding box in a specific direction
-     *
-     * @param direction
-     *            The direction to move this BB
-     * @return A new BB representing this BB translated by direction
-     */
-    public BoundingBox translate(BlockVector direction)
-    {
-        // TODO
-        return this;
-    }
-
 }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/MaterialAndData.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/MaterialAndData.java
@@ -69,9 +69,9 @@ import javax.annotation.Nullable;
  * be saved.
  */
 public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.MaterialAndData {
-    protected Material material;
-    protected Short data;
-    protected BlockExtraData extraData;
+    protected @Nullable Material material;
+    protected @Nullable Short data;
+    protected @Nullable BlockExtraData extraData;
     protected boolean isValid = true;
 
     public Material DEFAULT_MATERIAL = Material.AIR;
@@ -470,16 +470,19 @@ public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.Mater
         }
     }
 
+    @Nullable
     @Override
     public Short getData() {
         return data;
     }
 
+    @Nullable
     @Override
     public Byte getBlockData() {
         return data == null ? null : (byte)(short)data;
     }
 
+    @Nullable
     @Override
     public Material getMaterial() {
         return material;
@@ -576,6 +579,7 @@ public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.Mater
         return false;
     }
 
+    @Nullable
     @Override
     public ItemStack getItemStack(int amount)
     {
@@ -683,6 +687,7 @@ public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.Mater
         return getName(null);
     }
     
+    @Nullable
     @Override
     public String getBaseName() {
         if (material == null) {
@@ -782,6 +787,7 @@ public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.Mater
         }
     }
 
+    @Nullable
     @Override
     public String getCommandLine() {
         if (extraData != null && extraData instanceof BlockCommand) {
@@ -812,6 +818,7 @@ public class MaterialAndData implements com.elmakers.mine.bukkit.api.block.Mater
         return (isValid() ? material + (data != 0 ? "@" + data : "") : "invalid");
     }
 
+    @Nullable
     @SuppressWarnings("deprecation")
     @Override
     public MaterialData getMaterialData() {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/MaterialBrush.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/MaterialBrush.java
@@ -1,5 +1,15 @@
 package com.elmakers.mine.bukkit.block;
 
+import com.elmakers.mine.bukkit.api.block.BrushMode;
+import com.elmakers.mine.bukkit.api.block.Schematic;
+import com.elmakers.mine.bukkit.api.data.BrushData;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.MageController;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.entity.EntityData;
+import com.elmakers.mine.bukkit.maps.BufferedMapCanvas;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -7,12 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
-
-import com.elmakers.mine.bukkit.api.block.BrushMode;
-import com.elmakers.mine.bukkit.api.data.BrushData;
-import com.elmakers.mine.bukkit.api.magic.MageController;
-import com.elmakers.mine.bukkit.api.magic.Messages;
-import com.elmakers.mine.bukkit.utility.InventoryUtils;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -31,12 +36,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 import org.bukkit.util.Vector;
-
-import com.elmakers.mine.bukkit.api.block.Schematic;
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.entity.EntityData;
-import com.elmakers.mine.bukkit.maps.BufferedMapCanvas;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 
 public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.bukkit.api.block.MaterialBrush {
 
@@ -233,10 +232,12 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return brushKey;
     }
 
+    @Nullable
     public static MaterialBrush parseMaterialKey(String materialKey) {
         return parseMaterialKey(materialKey, false);
     }
 
+    @Nullable
     public static MaterialBrush parseMaterialKey(String materialKey, boolean allowItems) {
         if (materialKey == null || materialKey.length() == 0) return null;
         MaterialBrush brush = new MaterialBrush(materialKey);
@@ -370,7 +371,7 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return true;
     }
 
-    public Location toTargetLocation(Location target) {
+    @Nullable public Location toTargetLocation(Location target) {
         if (cloneSource == null || cloneTarget == null) return null;
         Location translated = cloneSource.clone();
         translated.subtract(cloneTarget.toVector());
@@ -378,7 +379,7 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return translated;
     }
 
-    public Location fromTargetLocation(World targetWorld, Location target) {
+    @Nullable public Location fromTargetLocation(World targetWorld, Location target) {
         if (cloneSource == null || cloneTarget == null) return null;
         Location translated = target.clone();
         translated.setX(translated.getBlockX());
@@ -547,9 +548,9 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return mode == BrushMode.CLONE || mode == BrushMode.REPLICATE || mode == BrushMode.SCHEMATIC;
     }
 
+    @Nullable
     @Override
-    public Collection<Entity> getTargetEntities()
-    {
+    public Collection<Entity> getTargetEntities() {
         if (cloneTarget == null || mage == null) return null;
 
         if (mode == BrushMode.CLONE || mode == BrushMode.REPLICATE || mode == BrushMode.SCHEMATIC)
@@ -573,9 +574,9 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return null;
     }
 
+    @Nullable
     @Override
-    public Collection<com.elmakers.mine.bukkit.api.entity.EntityData> getEntities()
-    {
+    public Collection<com.elmakers.mine.bukkit.api.entity.EntityData> getEntities() {
         if (cloneTarget == null) return null;
 
         if ((mode == BrushMode.CLONE || mode == BrushMode.REPLICATE) && cloneSource != null)
@@ -767,7 +768,7 @@ public class MaterialBrush extends MaterialAndData implements com.elmakers.mine.
         return mode == BrushMode.ERASE || (mode == BrushMode.MATERIAL && material == Material.AIR);
     }
 
-    public ItemStack getItem(MageController controller, boolean isItem) {
+    @Nullable public ItemStack getItem(MageController controller, boolean isItem) {
         Messages messages = controller.getMessages();
         MaterialAndData icon = new MaterialAndData(this.getMaterial(), this.getData());
         String extraLore = null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/Schematic.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/Schematic.java
@@ -3,6 +3,12 @@ package com.elmakers.mine.bukkit.block;
 import com.elmakers.mine.bukkit.api.block.MaterialAndData;
 import com.elmakers.mine.bukkit.api.entity.EntityData;
 import com.elmakers.mine.bukkit.utility.NMSUtils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.bukkit.Art;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -11,12 +17,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class Schematic implements com.elmakers.mine.bukkit.api.block.Schematic {
     private volatile boolean loaded = false;
@@ -155,6 +155,7 @@ public class Schematic implements com.elmakers.mine.bukkit.api.block.Schematic {
         return (x >= 0 && x <= size.getBlockX() && y >= 0 && y <= size.getBlockY() && z >= 0 && z <= size.getBlockZ());
     }
 
+    @Nullable
     @Override
     public MaterialAndData getBlock(Vector v) {
         int x = v.getBlockX() + center.getBlockX();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoList.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoList.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.batch.Batch;
@@ -98,7 +99,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
 
     private boolean                 consumed = false;
     private boolean                 undoEntityEffects = true;
-    private Set<EntityType>         undoEntityTypes = null;
+    private @Nullable Set<EntityType>   undoEntityTypes = null;
     protected boolean               undoBreakable = false;
     protected boolean               undoReflective = false;
     protected boolean               undoBreaking = false;
@@ -346,6 +347,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
     }
 
     @Override
+    @Nullable
     public BlockData undoNext(boolean applyPhysics)
     {
         if (blockList.size() == 0) {
@@ -600,6 +602,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
     }
 
     @Override
+    @Nullable
     public EntityData modify(Entity entity)
     {
         EntityData entityData = null;
@@ -626,6 +629,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
     }
 
     @Override
+    @Nullable
     public EntityData damage(Entity entity) {
         EntityData data = modify(entity);
         // Kind of a hack to prevent dropping hanging entities that we're going to undo later
@@ -810,6 +814,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
     }
 
     @Override
+    @Nullable
     public CastContext getContext() {
         return context == null ? null : context.get();
     }
@@ -826,7 +831,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
 
     @Override
     public int compareTo(com.elmakers.mine.bukkit.api.block.UndoList o) {
-        return (int)(scheduledTime - o.getScheduledTime());
+        return Long.compare(scheduledTime, o.getScheduledTime());
     }
 
     @Override
@@ -883,13 +888,13 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
         this.next = null;
     }
 
-    public UndoList getNext()
-    {
+    @Nullable
+    public UndoList getNext() {
         return next;
     }
 
-    public UndoList getPrevious()
-    {
+    @Nullable
+    public UndoList getPrevious() {
         return previous;
     }
 
@@ -917,6 +922,7 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
         return modifyType;
     }
 
+    @Nullable
     public static com.elmakers.mine.bukkit.api.block.UndoList getUndoList(Entity entity) {
         com.elmakers.mine.bukkit.api.block.UndoList blockList = null;
         if (entity != null && entity.hasMetadata("MagicBlockList")) {
@@ -941,10 +947,12 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
         return blockList;
     }
 
+    @Nullable
     public static BlockData getBlockData(Location location) {
         return registry.getBlockData(location);
     }
 
+    @Nullable
     public static com.elmakers.mine.bukkit.api.block.UndoList getUndoList(Location location) {
         BlockData blockData = getBlockData(location);
         return blockData == null ? null : blockData.getUndoList();
@@ -1035,8 +1043,9 @@ public class UndoList extends BlockList implements com.elmakers.mine.bukkit.api.
     public int getRunnableCount() {
         return runnables == null ? 0 : runnables.size();
     }
-    
+
     @Override
+    @Nullable
     public Runnable undoNextRunnable() {
         Runnable undone = null;
         if (runnables != null && !runnables.isEmpty()) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoQueue.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoQueue.java
@@ -4,11 +4,11 @@ import com.elmakers.mine.bukkit.api.data.UndoData;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.spell.Spell;
-import org.bukkit.block.Block;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.bukkit.block.Block;
 
 public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
 {
@@ -108,12 +108,14 @@ public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
          return head == null;
     }
 
+    @Nullable
     @Override
     public UndoList getLast()
     {
         return head;
     }
 
+    @Nullable
     @Override
     public UndoList getLast(Block target)
     {
@@ -135,11 +137,13 @@ public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
         maxSize = size;
     }
 
+    @Nullable
     public UndoList undo()
     {
         return undoRecent(0);
     }
 
+    @Nullable
     public UndoList undo(Block target)
     {
         return undoRecent(target, 0);
@@ -158,12 +162,14 @@ public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
      * @param timeout How long ago the UndoList may have been modified
      * @return The UndoList that was undone, or null if none.
      */
+    @Nullable
     @Override
     public UndoList undoRecent(int timeout)
     {
         return undoRecent(timeout, null);
     }
 
+    @Nullable
     @Override
     public UndoList undoRecent(int timeout, String spellKey)
     {
@@ -204,6 +210,7 @@ public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
      * @param timeout How long ago the UndoList may have been modified
      * @return The UndoList that was undone, or null if the Mage has no constructions for the given Block.
      */
+    @Nullable
     @Override
     public UndoList undoRecent(Block block, int timeout)
     {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoRegistry.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/block/UndoRegistry.java
@@ -1,13 +1,12 @@
 package com.elmakers.mine.bukkit.block;
 
 import com.elmakers.mine.bukkit.api.block.BlockData;
-
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
 
 public class UndoRegistry {
     protected Map<Long, BlockData> modified = new HashMap<>();
@@ -128,7 +127,7 @@ public class UndoRegistry {
         return currentAmount;
     }
 
-    public BlockData getBlockData(Location location) {
+    @Nullable public BlockData getBlockData(Location location) {
         long blockId = com.elmakers.mine.bukkit.block.BlockData.getBlockId(location.getBlock());
 
         // Prefer to return blocks that are watched by lists which are going to auto-undo.
@@ -155,10 +154,12 @@ public class UndoRegistry {
         return block != null && breakable.containsKey(com.elmakers.mine.bukkit.block.BlockData.getBlockId(block));
     }
 
+    @Nullable
     public Double getReflective(Block block) {
         return block == null ? null : reflective.get(com.elmakers.mine.bukkit.block.BlockData.getBlockId(block));
     }
 
+    @Nullable
     public Double getBreakable(Block block) {
         return block == null ? null : breakable.get(com.elmakers.mine.bukkit.block.BlockData.getBlockId(block));
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/data/ConfigurationMageDataStore.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/data/ConfigurationMageDataStore.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 public abstract class ConfigurationMageDataStore implements MageDataStore {
     protected MageController controller;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectLibManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectLibManager.java
@@ -5,6 +5,11 @@ import de.slikey.effectlib.Effect;
 import de.slikey.effectlib.EffectManager;
 import de.slikey.effectlib.util.DynamicLocation;
 import de.slikey.effectlib.util.ParticleEffect;
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.configuration.ConfigurationSection;
@@ -13,11 +18,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.io.File;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Manages EffectLib integration
@@ -53,7 +53,7 @@ public class EffectLibManager {
         }
     }
 
-    public Effect play(ConfigurationSection configuration, EffectPlayer player, DynamicLocation origin, DynamicLocation target, Map<String, String> parameterMap) {
+    @Nullable public Effect play(ConfigurationSection configuration, EffectPlayer player, DynamicLocation origin, DynamicLocation target, Map<String, String> parameterMap) {
         if (parameterMap == null) {
             parameterMap = new HashMap<>();
         }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
@@ -1,14 +1,14 @@
 package com.elmakers.mine.bukkit.effect;
 
-import java.util.*;
-
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.effect.EffectPlay;
-
+import com.elmakers.mine.bukkit.block.MaterialAndData;
 import com.elmakers.mine.bukkit.magic.SourceLocation;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import de.slikey.effectlib.util.DynamicLocation;
 import de.slikey.effectlib.util.ParticleEffect;
-
+import java.util.*;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Effect;
@@ -22,9 +22,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
-
-import com.elmakers.mine.bukkit.block.MaterialAndData;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 
 public abstract class EffectPlayer implements com.elmakers.mine.bukkit.api.effect.EffectPlayer {
     private static final String EFFECT_BUILTIN_CLASSPATH = "com.elmakers.mine.bukkit.effect.builtin";
@@ -579,21 +576,21 @@ public abstract class EffectPlayer implements com.elmakers.mine.bukkit.api.effec
         this.color = color;
     }
 
-    public Color getColor1() {
+    @Nullable public Color getColor1() {
         return useColor ? (color1 != null ? color1 : color) : null;
     }
 
-    public Color getColor2() {
+    @Nullable public Color getColor2() {
         return useColor ? (color2 != null ? color2 : color) : null;
     }
 
     public abstract void play();
 
-    public Location getOrigin() {
+    @Nullable public Location getOrigin() {
         return origin == null ? null : origin.getLocation();
     }
 
-    public Location getTarget() {
+    @Nullable public Location getTarget() {
         return target == null ? null : target.getLocation();
     }
 
@@ -619,11 +616,11 @@ public abstract class EffectPlayer implements com.elmakers.mine.bukkit.api.effec
         }
     }
 
-    public Entity getOriginEntity() {
+    @Nullable public Entity getOriginEntity() {
         return origin == null ? null : origin.getEntity();
     }
 
-    public Entity getTargetEntity() {
+    @Nullable public Entity getTargetEntity() {
         return target == null ? null : target.getEntity();
     }
 
@@ -682,11 +679,13 @@ public abstract class EffectPlayer implements com.elmakers.mine.bukkit.api.effec
         this.currentEffects = plays;
     }
 
+    @Nullable
     @Override
     public Location getSourceLocation(CastContext context)  {
         return sourceLocation.getLocation(context);
     }
 
+    @Nullable
     @Override
     public Location getTargetLocation(CastContext context)  {
         return targetLocation.getLocation(context);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
@@ -3,6 +3,11 @@ package com.elmakers.mine.bukkit.effect;
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
+import com.elmakers.mine.bukkit.utility.NMSUtils;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.Random;
+import javax.annotation.Nullable;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Location;
@@ -13,27 +18,23 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkMeta;
-
-import com.elmakers.mine.bukkit.utility.NMSUtils;
 import org.bukkit.util.Vector;
-
-import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.Random;
 
 public class EffectUtils extends NMSUtils {
     public static void spawnFireworkEffect(Server server, Location location, FireworkEffect effect, int power) {
         spawnFireworkEffect(server, location, effect, power, null, 2, 1);
     }
-    
+
     public static void spawnFireworkEffect(Server server, Location location, FireworkEffect effect, int power, boolean silent) {
         spawnFireworkEffect(server, location, effect, power, null, 2, 1, silent);
     }
 
+    @Nullable
     public static Entity spawnFireworkEffect(Server server, Location location, FireworkEffect effect, int power, Vector direction, Integer expectedLifespan, Integer ticksFlown) {
         return spawnFireworkEffect(server, location, effect, power, direction, expectedLifespan, ticksFlown, false);
     }
 
+    @Nullable
     public static Entity spawnFireworkEffect(Server server, Location location, FireworkEffect effect, int power, Vector direction, Integer expectedLifespan, Integer ticksFlown, boolean silent) {
         Entity entity = null;
         try {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/effect/HoloUtils.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/effect/HoloUtils.java
@@ -1,11 +1,11 @@
 package com.elmakers.mine.bukkit.effect;
 
 import com.elmakers.mine.bukkit.utility.NMSUtils;
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 
 /**
  * With much thanks to zombiekiller753 and Goblom!
@@ -15,7 +15,7 @@ public class HoloUtils extends NMSUtils
     private static int HORSE_AGE_OFFSET = -1700000; // Magic number for horse rendering glitch
     private static int Y_OFFSET = 55; // Offset to account for above
 
-    protected static Object createSkull(Location location)
+    @Nullable protected static Object createSkull(Location location)
     {
         Object skull = null;
         try {
@@ -32,7 +32,7 @@ public class HoloUtils extends NMSUtils
         return skull;
     }
 
-    protected static Object createHorse(Location location, String text)
+    @Nullable protected static Object createHorse(Location location, String text)
     {
         Object horse = null;
         try {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/effect/builtin/EffectVariable.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/effect/builtin/EffectVariable.java
@@ -43,9 +43,9 @@ public class EffectVariable extends EffectPlayer {
                 Collection<EffectPlayer> childPlayers = EffectPlayer.loadEffects(plugin, brightness, key);
                 brightnessMap.put(level, childPlayers);
                 for (EffectPlayer childPlayer : childPlayers) {
-                    playAtOrigin = playAtOrigin | childPlayer.playsAtOrigin();
-                    playAtAllTargets = playAtAllTargets | childPlayer.playsAtAllTargets();
-                    playAtTarget = playAtTarget | childPlayer.playsAtTarget();
+                    playAtOrigin |= childPlayer.playsAtOrigin();
+                    playAtAllTargets |= childPlayer.playsAtAllTargets();
+                    playAtTarget |= childPlayer.playsAtTarget();
                 }
 
             } catch (Exception ex) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/entity/EntityData.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/entity/EntityData.java
@@ -8,6 +8,17 @@ import com.elmakers.mine.bukkit.magic.MagicPlugin;
 import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.SafetyUtils;
+import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.bukkit.Art;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
@@ -46,17 +57,6 @@ import org.bukkit.material.Colorable;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
-
-import javax.annotation.Nonnull;
-import java.lang.ref.WeakReference;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Level;
 
 /**
  * This class stores information about an Entity.
@@ -221,7 +221,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         }
     }
     
-    private ItemData getItem(ItemStack item) {
+    @Nullable private ItemData getItem(ItemStack item) {
         return item == null ? null : new com.elmakers.mine.bukkit.item.ItemData(item);
     }
 
@@ -396,7 +396,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         this.uuid = entity == null ? null : entity.getUniqueId();
     }
 
-    @SuppressWarnings("deprecation")
+    @Nullable @SuppressWarnings("deprecation")
     public static EntityType parseEntityType(String typeString)
     {
         if (typeString == null) return null;
@@ -447,7 +447,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return health;
     }
 
-    protected Entity trySpawn(MageController controller, CreatureSpawnEvent.SpawnReason reason) {
+    @Nullable protected Entity trySpawn(MageController controller, CreatureSpawnEvent.SpawnReason reason) {
         Entity spawned = null;
         boolean addedToWorld = false;
         if (type != null && type != EntityType.PLAYER) {
@@ -481,6 +481,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return spawned;
     }
 
+    @Nullable
     @Override
     public EntityData getRelativeTo(Location center) {
         EntityData copy = this.clone();
@@ -495,21 +496,25 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return copy;
     }
 
+    @Nullable
     @Override
     public Entity spawn() {
         return spawn(null, null);
     }
 
+    @Nullable
     @Override
     public Entity spawn(Location location) {
         return spawn(null, location, null);
     }
 
+    @Nullable
     @Override
     public Entity spawn(MageController controller, Location location) {
         return spawn(controller, location, null);
     }
-    
+
+    @Nullable
     @Override
     public Entity spawn(MageController controller, Location location, CreatureSpawnEvent.SpawnReason reason) {
         if (location != null) this.location = location;
@@ -517,6 +522,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return trySpawn(controller, reason);
     }
 
+    @Nullable
     @Override
     public Entity undo() {
         Entity entity = this.getEntity();
@@ -671,7 +677,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return true;
     }
 
-    public ConfigurationSection getMageProperties() {
+    @Nullable public ConfigurationSection getMageProperties() {
         return mageData != null ? mageData.mageProperties : null;
     }
 
@@ -748,7 +754,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return isProjectile;
     }
 
-    public Entity getEntity() {
+    @Nullable public Entity getEntity() {
         return entity == null ? null : entity.get();
     }
     
@@ -757,6 +763,7 @@ public class EntityData implements com.elmakers.mine.bukkit.api.entity.EntityDat
         return name;
     }
 
+    @Nullable
     @Override
     public EntityData clone() {
         try {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/entity/EntityMageData.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/entity/EntityMageData.java
@@ -5,19 +5,19 @@ import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.magic.MageTrigger;
 import com.elmakers.mine.bukkit.magic.MageTrigger.MageTriggerType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class EntityMageData {
     // These properties will get copied directly to mage data, as if they were in the "mage" section.
@@ -92,7 +92,7 @@ public class EntityMageData {
         return !hasProperties && !hasTriggers && !aggro;
     }
 
-    private List<MageTrigger> getTriggers(MageTriggerType type) {
+    @Nullable private List<MageTrigger> getTriggers(MageTriggerType type) {
         return triggers == null ? null : triggers.get(type);
     }
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/essentials/MagicItemDb.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/essentials/MagicItemDb.java
@@ -5,6 +5,8 @@ import net.ess3.api.IEssentials;
 
 import org.bukkit.inventory.ItemStack;
 
+import javax.annotation.Nullable;
+
 import com.earth2me.essentials.ItemDb;
 import com.elmakers.mine.bukkit.magic.MagicController;
 import com.elmakers.mine.bukkit.wand.Wand;
@@ -18,7 +20,8 @@ public class MagicItemDb extends ItemDb {
 		this.controller = controller;
 		this.reloadConfig();
 	}
-	
+
+	@Nullable
 	@Override
 	public ItemStack get(final String id) throws Exception
 	{

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesManager.java
@@ -15,13 +15,6 @@ import com.herocraftonline.heroes.characters.Hero;
 import com.herocraftonline.heroes.characters.classes.HeroClass;
 import com.herocraftonline.heroes.characters.party.HeroParty;
 import com.herocraftonline.heroes.characters.skill.*;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.MemoryConfiguration;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +26,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 public class HeroesManager implements ManaController, AttributeProvider, TeamProvider {
     private Heroes heroes;
@@ -207,7 +206,7 @@ public class HeroesManager implements ManaController, AttributeProvider, TeamPro
         }
     }
 
-    public SpellTemplate createSkillSpell(MagicController controller, String skillName) {
+    @Nullable public SpellTemplate createSkillSpell(MagicController controller, String skillName) {
         if (skills == null) return null;
         Skill skill = skills.getSkill(skillName);
         if (skill == null) return null;
@@ -270,12 +269,12 @@ public class HeroesManager implements ManaController, AttributeProvider, TeamPro
         return heroClass.getName();
     }
 
-    protected Skill getSkill(String key) {
+    @Nullable protected Skill getSkill(String key) {
         if (skills == null) return null;
         return skills.getSkill(key);
     }
 
-    protected Hero getHero(Player player) {
+    @Nullable protected Hero getHero(Player player) {
         if (characters == null) return null;
         return characters.getHero(player);
     }
@@ -339,6 +338,7 @@ public class HeroesManager implements ManaController, AttributeProvider, TeamPro
         return attributes.keySet();
     }
 
+    @Nullable
     @Override
     public Double getAttributeValue(String attribute, Player player) {
         Double result = null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesSkillSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesSkillSpell.java
@@ -5,23 +5,23 @@ import com.elmakers.mine.bukkit.api.magic.Messages;
 import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
-import com.elmakers.mine.bukkit.spell.CastingCost;
-import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.elmakers.mine.bukkit.magic.MagicController;
 import com.elmakers.mine.bukkit.spell.BaseSpell;
+import com.elmakers.mine.bukkit.spell.CastingCost;
+import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.herocraftonline.heroes.characters.Hero;
 import com.herocraftonline.heroes.characters.skill.PassiveSkill;
 import com.herocraftonline.heroes.characters.skill.Skill;
 import com.herocraftonline.heroes.characters.skill.SkillConfigManager;
 import com.herocraftonline.heroes.characters.skill.SkillSetting;
+import java.util.List;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-
-import java.util.List;
-import java.util.logging.Level;
 
 public class HeroesSkillSpell extends BaseSpell {
     private String skillKey;
@@ -127,6 +127,7 @@ public class HeroesSkillSpell extends BaseSpell {
         return Math.max(0, cooldown - now);
     }
 
+    @Nullable
     @Override
     public CastingCost getRequiredCost() {
         if (isCasting || skill == null || mage == null) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesSpellSkill.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/heroes/HeroesSpellSkill.java
@@ -49,7 +49,7 @@ public class HeroesSpellSkill extends ActiveSkill {
      */
     private static String getSkillName(Heroes heroes, String spellKey) {
         Plugin magicPlugin = heroes.getServer().getPluginManager().getPlugin("Magic");
-        if (magicPlugin == null || !(magicPlugin instanceof MagicAPI) && !magicPlugin.isEnabled()) {
+        if (magicPlugin == null || (!(magicPlugin instanceof MagicAPI) && !magicPlugin.isEnabled())) {
             heroes.getLogger().warning("MagicHeroes skills require the Magic plugin");
             throw new RuntimeException("MagicHeroes skills require the Magic plugin");
         }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/MagicMACreature.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/MagicMACreature.java
@@ -5,6 +5,7 @@ import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.garbagemule.MobArena.framework.Arena;
 import com.garbagemule.MobArena.waves.MACreature;
 import com.garbagemule.MobArena.waves.WaveUtils;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Creature;
@@ -21,6 +22,7 @@ public class MagicMACreature extends MACreature {
         this.controller = controller;
     }
 
+    @Nullable
     @Override
     public LivingEntity spawn(Arena arena, World world, Location loc) {
         loc.setWorld(world);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/MobArenaManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/MobArenaManager.java
@@ -9,6 +9,9 @@ import com.garbagemule.MobArena.events.ArenaPlayerJoinEvent;
 import com.garbagemule.MobArena.events.ArenaPlayerLeaveEvent;
 import com.garbagemule.MobArena.framework.Arena;
 import com.garbagemule.MobArena.framework.ArenaMaster;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
@@ -17,9 +20,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
-
-import java.util.List;
-import java.util.Set;
 
 public class MobArenaManager implements Listener, BlockBreakManager, BlockBuildManager {
     private final MageController controller;
@@ -76,7 +76,7 @@ public class MobArenaManager implements Listener, BlockBreakManager, BlockBuildM
     }
 
     // Hopefully can use this again one day for custom item provider
-    public ItemStack getItem(String s) {
+    @Nullable public ItemStack getItem(String s) {
         if (!s.startsWith("magic:")) return null;
         s = s.substring(6);
         return controller.createItem(s);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/SkillAPIManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/SkillAPIManager.java
@@ -55,6 +55,7 @@ public class SkillAPIManager implements ManaController, AttributeProvider, Requi
         return attributes;
     }
 
+    @Nullable
     @Override
     public Double getAttributeValue(String attribute, Player player) {
         if (attributes == null || !attributes.contains(attribute)) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/SkriptManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/SkriptManager.java
@@ -19,6 +19,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import javax.annotation.Nullable;
+
 public class SkriptManager {
 
     public SkriptManager(MageController controller) {
@@ -35,33 +37,37 @@ public class SkriptManager {
         ExprTargets.register();
         ExprActiveSpell.register();
 
-		EventValues.registerEventValue(CastEvent.class, Player.class, new Getter<Player, CastEvent>() {
-			@Override
-			public Player get(final CastEvent e) {
-			return e.getMage().getPlayer();
-			}
-		}, 0);
+        EventValues.registerEventValue(CastEvent.class, Player.class, new Getter<Player, CastEvent>() {
+            @Nullable
+            @Override
+            public Player get(final CastEvent e) {
+                return e.getMage().getPlayer();
+            }
+        }, 0);
+        
+        EventValues.registerEventValue(CastEvent.class, Entity.class, new Getter<Entity, CastEvent>() {
+            @Nullable
+            @Override
+            public Entity get(final CastEvent e) {
+                return e.getMage().getEntity();
+            }
+        }, 0);
 
-		EventValues.registerEventValue(CastEvent.class, Entity.class, new Getter<Entity, CastEvent>() {
-			@Override
-			public Entity get(final CastEvent e) {
-			return e.getMage().getEntity();
-			}
-		}, 0);
-
-		EventValues.registerEventValue(PreCastEvent.class, Player.class, new Getter<Player, PreCastEvent>() {
-			@Override
-			public Player get(final PreCastEvent e) {
-			return e.getMage().getPlayer();
-			}
-		}, 0);
-
-		EventValues.registerEventValue(PreCastEvent.class, Entity.class, new Getter<Entity, PreCastEvent>() {
-			@Override
-			public Entity get(final PreCastEvent e) {
-			return e.getMage().getEntity();
-			}
-		}, 0);
+        EventValues.registerEventValue(PreCastEvent.class, Player.class, new Getter<Player, PreCastEvent>() {
+                @Nullable
+                @Override
+                public Player get(final PreCastEvent e) {
+                    return e.getMage().getPlayer();
+                }
+        }, 0);
+    
+        EventValues.registerEventValue(PreCastEvent.class, Entity.class, new Getter<Entity, PreCastEvent>() {
+            @Nullable
+            @Override
+            public Entity get(final PreCastEvent e) {
+                return e.getMage().getEntity();
+            }
+        }, 0);
 
         plugin.getLogger().info("Skript found:");
         plugin.getLogger().info("  Added events: cast, casting");

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/VaultController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/VaultController.java
@@ -1,5 +1,8 @@
 package com.elmakers.mine.bukkit.integration;
 
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import javax.annotation.Nullable;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.item.ItemInfo;
@@ -8,9 +11,6 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
-
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 
 public class VaultController {
     private static VaultController instance;
@@ -98,7 +98,7 @@ public class VaultController {
         return response.transactionSuccess();
     }
 
-    public String getItemName(Material material, short data) {
+    @Nullable public String getItemName(Material material, short data) {
         ItemInfo info = Items.itemByType(material, data);
         return info == null ? null : info.getName();
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/skript/ExprCaster.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/skript/ExprCaster.java
@@ -17,6 +17,8 @@ import com.elmakers.mine.bukkit.api.event.PreCastEvent;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 
+import javax.annotation.Nullable;
+
 @Name("Caster")
 @Description({"The caster of a spell event.",
 		"Please note that the attacker can also be a command block or the console, but this expression will not be set in these cases."})
@@ -43,7 +45,7 @@ public class ExprCaster extends SimpleExpression<Entity> {
 		return new Entity[] {getCaster(e)};
 	}
 
-	private static Entity getCaster(final Event e) {
+	@Nullable private static Entity getCaster(final Event e) {
 		if (e != null && e instanceof CastEvent) {
 		    return ((CastEvent)e).getMage().getEntity();
 		}
@@ -56,7 +58,7 @@ public class ExprCaster extends SimpleExpression<Entity> {
 	}
 
 	@Override
-	public String toString(final Event e, final boolean debug) {
+	public String toString(@Nullable Event e, final boolean debug) {
 		if (e == null)
 			return "the caster";
 		return Classes.getDebugMessage(getSingle(e));

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/integration/skript/ExprTargets.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/integration/skript/ExprTargets.java
@@ -44,7 +44,7 @@ public class ExprTargets extends SimpleExpression<Entity> {
 		if (e != null && e instanceof CastEvent) {
 		    return ((CastEvent)e).getSpell().getCurrentCast().getTargetedEntities().toArray(templateArray);
 		}
-		return null;
+		return new Entity[0];
 	}
 
 	@Override

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/item/ItemData.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/item/ItemData.java
@@ -6,10 +6,9 @@ import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.elmakers.mine.bukkit.utility.NMSUtils;
 import com.google.common.collect.ImmutableSet;
-
 import java.util.Collection;
 import java.util.Set;
-
+import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -116,6 +115,7 @@ public class ItemData implements com.elmakers.mine.bukkit.api.item.ItemData {
         return categories;
     }
 
+    @Nullable
     @Override
     public ItemStack getItemStack(int amount) {
         ItemStack newItem = InventoryUtils.getCopy(item);
@@ -141,6 +141,7 @@ public class ItemData implements com.elmakers.mine.bukkit.api.item.ItemData {
         return item == null ? Material.AIR : item.getType();
     }
 
+    @Nullable
     @SuppressWarnings("deprecation")
     @Override
     public MaterialData getMaterialData() {
@@ -150,6 +151,7 @@ public class ItemData implements com.elmakers.mine.bukkit.api.item.ItemData {
         return materialData;
     }
 
+    @Nullable
     @Override
     public ItemMeta getItemMeta() {
         return item == null ? null : item.getItemMeta();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/BaseMagicProperties.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/BaseMagicProperties.java
@@ -103,7 +103,6 @@ public class BaseMagicProperties implements MagicProperties {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> T getProperty(String key, T defaultValue) {
         Preconditions.checkNotNull(key, "key");
         Preconditions.checkNotNull(defaultValue, "defaultValue");
@@ -117,17 +116,17 @@ public class BaseMagicProperties implements MagicProperties {
         }
         if (value != null && value instanceof Number && defaultValue instanceof Number) {
             if (defaultValue instanceof Double) {
-                return (T)(Double)NumberConversions.toDouble(value);
+                return clazz.cast(NumberConversions.toDouble(value));
             } else if (defaultValue instanceof Integer) {
-                return (T)(Integer)NumberConversions.toInt(value);
+                return clazz.cast(NumberConversions.toInt(value));
             } else if (defaultValue instanceof Byte) {
-                return (T)(Byte)NumberConversions.toByte(value);
+                return clazz.cast(NumberConversions.toByte(value));
             } else if (defaultValue instanceof Float) {
-                return (T)(Float)NumberConversions.toFloat(value);
+                return clazz.cast(NumberConversions.toFloat(value));
             } else if (defaultValue instanceof Long) {
-                return (T)(Long)NumberConversions.toLong(value);
+                return clazz.cast(NumberConversions.toLong(value));
             } else if (defaultValue instanceof Short) {
-                return (T)(Short)NumberConversions.toShort(value);
+                return clazz.cast(NumberConversions.toShort(value));
             }
         }
 
@@ -197,11 +196,13 @@ public class BaseMagicProperties implements MagicProperties {
         return getString(key, null);
     }
 
+    @Nullable
     public ConfigurationSection getConfigurationSection(String key) {
         Object value = getProperty(key);
         return value == null || !(value instanceof ConfigurationSection) ? null : (ConfigurationSection)value;
     }
 
+    @Nullable
     public Vector getVector(String key, Vector def) {
         String stringData = getString(key, null);
         if (stringData == null) {
@@ -211,6 +212,7 @@ public class BaseMagicProperties implements MagicProperties {
         return ConfigurationUtils.toVector(stringData);
     }
 
+    @Nullable
     public Vector getVector(String key) {
         return getVector(key, null);
     }
@@ -219,6 +221,7 @@ public class BaseMagicProperties implements MagicProperties {
         return configuration;
     }
 
+    @Nullable
     protected static String getPotionEffectString(Map<PotionEffectType, Integer> potionEffects) {
         if (potionEffects.size() == 0) return null;
         Collection<String> effectStrings = new ArrayList<>();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/CasterProperties.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/CasterProperties.java
@@ -264,6 +264,7 @@ public abstract class CasterProperties extends BaseMagicConfigurable implements 
         return level == null ? 1 : level;
     }
 
+    @Nullable
     public SpellTemplate getBaseSpell(String spellKey) {
         SpellKey key = new SpellKey(spellKey);
         Collection<String> spells = getSpells();
@@ -317,8 +318,9 @@ public abstract class CasterProperties extends BaseMagicConfigurable implements 
 		return spellSet;
     }
 
-	@Override
-    public @Nullable Spell getSpell(String spellKey) {
+    @Nullable
+    @Override
+    public Spell getSpell(String spellKey) {
         Mage mage = getMage();
 		if (mage == null) {
 			return null;
@@ -350,6 +352,7 @@ public abstract class CasterProperties extends BaseMagicConfigurable implements 
         return brushes;
     }
 
+    @Nullable
     @Override
     public ProgressionPath getPath() {
         String pathKey = getString("path");
@@ -389,6 +392,7 @@ public abstract class CasterProperties extends BaseMagicConfigurable implements 
         return super.upgrade(key, value);
     }
 
+	@Nullable
     @Override
     public Double getAttribute(String attributeKey) {
         ConfigurationSection attributes = getConfigurationSection("attributes");
@@ -438,7 +442,9 @@ public abstract class CasterProperties extends BaseMagicConfigurable implements 
 	}
 
     public abstract boolean isPlayer();
+    @Nullable
     public abstract Player getPlayer();
+    @Nullable
     @Override
     public abstract Mage getMage();
 }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/Mage.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/Mage.java
@@ -45,6 +45,7 @@ import com.elmakers.mine.bukkit.api.wand.WandAction;
 import com.elmakers.mine.bukkit.wand.WandManaMode;
 import com.elmakers.mine.bukkit.wand.WandMode;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import de.slikey.effectlib.util.VectorUtils;
@@ -246,7 +247,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return new HashSet<Spell>(activeSpells);
     }
 
-    public Inventory getStoredInventory() {
+    @Nullable public Inventory getStoredInventory() {
         return activeWand != null ? activeWand.getStoredInventory() : null;
     }
 
@@ -862,6 +863,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return undoQueue;
     }
 
+    @Nullable
     @Override
     public UndoList getLastUndoList() {
         if (undoQueue == null || undoQueue.isEmpty()) return null;
@@ -1364,7 +1366,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         sendMessage(controller.getMessages().get(key, key));
     }
 
-    private Wand checkWand(ItemStack itemInHand) {
+    @Nullable private Wand checkWand(ItemStack itemInHand) {
         Player player = getPlayer();
         if (isLoading() || player == null) return null;
 
@@ -1433,7 +1435,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return wasActive;
     }
 
-    private Wand checkOffhandWand() {
+    @Nullable private Wand checkOffhandWand() {
         Player player = getPlayer();
         if (player == null) {
             return null;
@@ -1441,7 +1443,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return checkOffhandWand(player.getInventory().getItemInOffHand());
     }
 
-    private Wand checkOffhandWand(ItemStack itemInHand) {
+    @Nullable private Wand checkOffhandWand(ItemStack itemInHand) {
         Player player = getPlayer();
         if (isLoading() || player == null) return null;
 
@@ -1476,6 +1478,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         Bukkit.getScheduler().scheduleSyncDelayedTask(controller.getPlugin(), new CheckWandTask(this));
     }
 
+    @Nullable
     @Override
     public Wand checkWand() {
         Player player = getPlayer();
@@ -1678,7 +1681,11 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         if (location != null) return location.clone();
 
         LivingEntity livingEntity = getLivingEntity();
-        if (livingEntity == null) return null;
+        // FIXME: Is this a valid precondition?
+        // Callers don't seem to check for null when calling this. 
+        Preconditions.checkState(
+                livingEntity != null, 
+                "Mage neither has a living entity nor a location: %s", this);
         return livingEntity.getLocation();
     }
 
@@ -1692,6 +1699,8 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return getLocation();
     }
 
+    // TODO: Should this be non null?
+    @Nullable
     @Override
     public Location getCastLocation() {
         Location castLocation = getEyeLocation();
@@ -1708,6 +1717,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return castLocation;
     }
 
+    @Nullable
     @Override
     public Location getWandLocation() {
         return getCastLocation();
@@ -1739,6 +1749,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return baseLocation;
     }
 
+    @Nullable
     @Override
     public Location getOffhandWandLocation() {
         Location wandLocation = getEyeLocation();
@@ -1757,21 +1768,25 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return new Vector(0, 1, 0);
     }
 
+    @Nullable
     @Override
     public UndoList undo(Block target) {
         return getUndoQueue().undo(target);
     }
 
+    @Nullable
     @Override
     public Batch cancelPending() {
         return cancelPending(null, true);
     }
 
+    @Nullable
     @Override
     public Batch cancelPending(String spellKey) {
         return cancelPending(spellKey, true);
     }
 
+    @Nullable
     @Override
     public Batch cancelPending(boolean force) {
         return cancelPending(null, force);
@@ -1797,6 +1812,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return finished;
     }
 
+    @Nullable
     @Override
     public Batch cancelPending(String spellKey, boolean force) {
         Batch stoppedPending = null;
@@ -1841,6 +1857,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return stoppedPending;
     }
 
+    @Nullable
     @Override
     public UndoList undo() {
         return getUndoQueue().undo();
@@ -1861,6 +1878,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return spells.containsKey(key);
     }
 
+    @Nullable
     @Override
     public MageSpell getSpell(String key) {
         if (loading) return null;
@@ -1883,7 +1901,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return playerSpell;
     }
 
-    protected MageSpell createSpell(String key) {
+    @Nullable protected MageSpell createSpell(String key) {
         MageSpell playerSpell = spells.get(key);
         if (playerSpell != null) {
             playerSpell.setMage(this);
@@ -2048,6 +2066,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         }
     }
 
+    @Nullable
     @Override
     public Color getEffectColor() {
         if (offhandCast && offhandWand != null) {
@@ -2057,6 +2076,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return activeWand.getEffectColor();
     }
 
+    @Nullable
     @Override
     public String getEffectParticleName() {
         if (offhandCast && offhandWand != null) {
@@ -2118,6 +2138,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return controller;
     }
 
+    @Nullable
     @Override
     @Deprecated
     public Set<Material> getRestrictedMaterials() {
@@ -2193,6 +2214,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return getLocation() != null;
     }
 
+    @Nullable
     @Override
     public Inventory getInventory() {
         if (hasStoredInventory()) {
@@ -2279,6 +2301,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return hasItem(itemStack, false);
     }
 
+    @Nullable
     @Override
     @Deprecated
     public Wand getSoulWand() {
@@ -2553,6 +2576,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         }
     }
 
+    @Nullable
     @Override
     public Player getPlayer() {
         return isNPC ? null : _player.get();
@@ -2568,6 +2592,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return entityData;
     }
 
+    @Nullable
     @Override
     public LivingEntity getLivingEntity() {
         Entity entity = _entity.get();
@@ -3373,6 +3398,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         return boundWands.get(template);
     }
 
+    @Nullable
     @Override
     public WandUpgradePath getBoundWandPath(String templateKey) {
         com.elmakers.mine.bukkit.api.wand.Wand boundWand = boundWands.get(templateKey);
@@ -3664,6 +3690,7 @@ public class Mage implements CostReducer, com.elmakers.mine.bukkit.api.magic.Mag
         this.lastActivatedSlot = slot;
     }
 
+    @Nullable
     @Override
     public Double getAttribute(String attributeKey) {
         Double attribute = attributes.get(attributeKey);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MageClass.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MageClass.java
@@ -137,6 +137,7 @@ public class MageClass extends TemplatedProperties implements com.elmakers.mine.
         return effectiveConfiguration;
     }
 
+    @Nullable
     @Override
     protected BaseMagicConfigurable getStorage(MagicPropertyType propertyType) {
         switch (propertyType) {
@@ -166,6 +167,7 @@ public class MageClass extends TemplatedProperties implements com.elmakers.mine.
         return mageProperties.isPlayer();
     }
 
+    @Nullable
     @Override
     public Player getPlayer() {
         return mageProperties.getPlayer();
@@ -217,6 +219,7 @@ public class MageClass extends TemplatedProperties implements com.elmakers.mine.
         mage.updatePassiveEffects();
     }
 
+    @Nullable
     @Override
     public ProgressionPath getPath() {
         String pathKey = getString("path");

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MageProperties.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MageProperties.java
@@ -1,6 +1,6 @@
 package com.elmakers.mine.bukkit.magic;
 
-import org.bukkit.ChatColor;
+
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -34,6 +34,7 @@ public class MageProperties extends CasterProperties {
         return mage.isPlayer();
     }
 
+    @Nullable
     @Override
     public Player getPlayer() {
         return mage.getPlayer();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
@@ -128,8 +128,8 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.projectiles.ProjectileSource;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
+
+
 import org.bukkit.util.Vector;
 
 import java.io.BufferedInputStream;
@@ -183,6 +183,7 @@ public class MagicController implements MageController {
         defaultsFolder.mkdirs();
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.magic.Mage getRegisteredMage(String mageId) {
         if (!loaded) {
@@ -218,7 +219,9 @@ public class MagicController implements MageController {
             if (entity instanceof Player) {
                 getLogger().warning("Player data request for " + mageId + " (" + ((Player)commandSender).getName() + ") failed, plugin not loaded yet");
             }
-            return null;
+            // FIXME
+            throw new RuntimeException();
+            //return null;
         }
 
         if (!mages.containsKey(mageId)) {
@@ -308,6 +311,8 @@ public class MagicController implements MageController {
         if (apiMage == null) {
             getLogger().warning("getMage returning null mage for " + entity + " and " + commandSender);
             Thread.dumpStack();
+            // FIXME
+            throw new RuntimeException();
         }
         return apiMage;
     }
@@ -468,6 +473,7 @@ public class MagicController implements MageController {
         return worthSkillPoints;
     }
 
+    @Nullable
     @Override
     public ItemStack getWorthItem() {
         return currencyItem == null ? null : currencyItem.getItem();
@@ -635,6 +641,7 @@ public class MagicController implements MageController {
         maps.resetAll();
     }
 
+    @Nullable
     @Override
     public Schematic loadSchematic(String schematicName) {
         if (schematicName == null || schematicName.length() == 0) return null;
@@ -1348,7 +1355,7 @@ public class MagicController implements MageController {
         return new File(dataFolder, fileName + ".yml");
     }
 
-    protected ConfigurationSection loadDataFile(String fileName) {
+    @Nullable protected ConfigurationSection loadDataFile(String fileName) {
         File dataFile = getDataFile(fileName);
         if (!dataFile.exists()) {
             return null;
@@ -1902,10 +1909,12 @@ public class MagicController implements MageController {
         }
     }
 
+    @Nullable
     protected String getChunkKey(Block block) {
         return getChunkKey(block.getLocation());
     }
 
+    @Nullable
     protected String getChunkKey(Location location) {
         World world = location.getWorld();
         if (world == null) return null;
@@ -2056,18 +2065,19 @@ public class MagicController implements MageController {
         Bukkit.getPluginManager().callEvent(saveEvent);
 	}
 
-    protected ConfigurationSection getSpellConfig(String key, ConfigurationSection config)
-    {
+    @Nullable
+    protected ConfigurationSection getSpellConfig(String key, ConfigurationSection config) {
         return getSpellConfig(key, config, true);
     }
 
+    @Nullable
     protected ConfigurationSection getSpellConfig(String key, ConfigurationSection config, boolean addInherited) {
         resolvingKeys.clear();
         return getSpellConfig(key, config, addInherited, resolvingKeys);
     }
 
-    protected ConfigurationSection getSpellConfig(String key, ConfigurationSection config, boolean addInherited, Set<String> resolving)
-    {
+    @Nullable
+    protected ConfigurationSection getSpellConfig(String key, ConfigurationSection config, boolean addInherited, Set<String> resolving) {
         // Catch circular dependencies
         if (resolvingKeys.contains(key)) {
             getLogger().log(Level.WARNING, "Circular dependency detected in spell configs: " + StringUtils.join(resolvingKeys, " -> ") + " -> " + key);
@@ -2225,7 +2235,7 @@ public class MagicController implements MageController {
 		}
 	}
 
-	public static Spell loadSpell(String name, ConfigurationSection node, MageController controller)
+	@Nullable public static Spell loadSpell(String name, ConfigurationSection node, MageController controller)
 	{
 		String className = node.getString("class");
 		if (className == null || className.equalsIgnoreCase("action") || className.equalsIgnoreCase("actionspell") )
@@ -2276,16 +2286,19 @@ public class MagicController implements MageController {
 		return newSpell;
 	}
 
+    @Nullable
     @Override
     public String getReflectiveMaterials(Mage mage, Location location) {
         return worldGuardManager.getReflective(mage.getPlayer(), location);
     }
 
+    @Nullable
     @Override
     public String getDestructibleMaterials(Mage mage, Location location) {
         return worldGuardManager.getDestructible(mage.getPlayer(), location);
     }
 
+    @Nullable
     @Override
     public Set<String> getSpellOverrides(Mage mage, Location location) {
         return worldGuardManager.getSpellOverrides(mage.getPlayer(), location);
@@ -2805,6 +2818,7 @@ public class MagicController implements MageController {
         return hasPermission(sender, spell.getPermissionNode());
     }
 
+    @Nullable
     @Override
     public Boolean getRegionCastPermission(Player player, SpellTemplate spell, Location location)
     {
@@ -2812,6 +2826,7 @@ public class MagicController implements MageController {
         return worldGuardManager.getCastPermission(player, spell, location);
     }
 
+    @Nullable
     @Override
     public Boolean getPersonalCastPermission(Player player, SpellTemplate spell, Location location)
     {
@@ -2857,7 +2872,7 @@ public class MagicController implements MageController {
 		return hasPermission((Player) sender, pNode, defaultValue);
 	}
 
-    public UndoList getPendingUndo(Location location)
+    @Nullable public UndoList getPendingUndo(Location location)
     {
         return com.elmakers.mine.bukkit.block.UndoList.getUndoList(location);
     }
@@ -2869,7 +2884,7 @@ public class MagicController implements MageController {
         }
 	}
 	
-	public UndoList getEntityUndo(Entity entity) {
+	@Nullable public UndoList getEntityUndo(Entity entity) {
 		UndoList blockList = null;
 		if (entity == null) return null;
         Mage mage = getRegisteredMage(entity);
@@ -3056,7 +3071,7 @@ public class MagicController implements MageController {
         }
     }
 
-	public ItemStack removeItemFromWand(Wand wand, ItemStack droppedItem) {
+	@Nullable public ItemStack removeItemFromWand(Wand wand, ItemStack droppedItem) {
 		if (wand == null || droppedItem == null || Wand.isWand(droppedItem)) {
 			return null;
 		}
@@ -3359,7 +3374,7 @@ public class MagicController implements MageController {
     @Override
     @Deprecated
     public Set<Material> getBuildingMaterials() {
-        return MaterialSets.toLegacy(buildingMaterials);
+        return MaterialSets.toLegacyNN(buildingMaterials);
     }
 
     @Override
@@ -3371,13 +3386,13 @@ public class MagicController implements MageController {
     @Override
     @Deprecated
     public Set<Material> getDestructibleMaterials() {
-        return MaterialSets.toLegacy(destructibleMaterials);
+        return MaterialSets.toLegacyNN(destructibleMaterials);
     }
 
     @Override
     @Deprecated
     public Set<Material> getRestrictedMaterials() {
-        return MaterialSets.toLegacy(restrictedMaterials);
+        return MaterialSets.toLegacyNN(restrictedMaterials);
     }
 
     @Override
@@ -3419,6 +3434,7 @@ public class MagicController implements MageController {
         return getMaterialSetManager().getMaterialSets();
     }
 
+    @Nullable
     @Override
     @Deprecated
     public Set<Material> getMaterialSet(String string) {
@@ -3503,8 +3519,9 @@ public class MagicController implements MageController {
         return false;
     }
 
+    @Nullable
     @Override
-	public Location getWarp(String warpName) {
+    public Location getWarp(String warpName) {
         Location location = null;
 		if (warpController != null) {
             try {
@@ -3516,11 +3533,13 @@ public class MagicController implements MageController {
 		return location;
 	}
 
+    @Nullable
     @Override
     public Location getTownLocation(Player player) {
         return townyManager.getTownLocation(player);
     }
 
+    @Nullable
     @Override
     public Map<String, Location> getHomeLocations(Player player) {
         return preciousStonesManager.getFieldLocations(player);
@@ -3543,9 +3562,9 @@ public class MagicController implements MageController {
 		return false;
 	}
 
-	@Override
-	public UndoList undoAny(Block target)
-	{
+    @Nullable
+    @Override
+    public UndoList undoAny(Block target) {
 		for (Mage mage : mages.values())
 		{
 			UndoList undid = mage.undo(target);
@@ -3558,6 +3577,7 @@ public class MagicController implements MageController {
 		return null;
 	}
 
+    @Nullable
     @Override
     public UndoList undoRecent(Block target, int timeout)
     {
@@ -3590,11 +3610,13 @@ public class MagicController implements MageController {
         return new Wand(this, config);
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.wand.Wand createWand(String wandKey) {
         return Wand.createWand(this, wandKey);
     }
 
+    @Nullable
     @Override
     public WandTemplate getWandTemplate(String key) {
         if (key == null || key.isEmpty()) return null;
@@ -3606,11 +3628,13 @@ public class MagicController implements MageController {
         return new ArrayList<com.elmakers.mine.bukkit.api.wand.WandTemplate>(wandTemplates.values());
     }
 
+    @Nullable
     protected ConfigurationSection resolveConfiguration(String key, ConfigurationSection properties, Map<String, ConfigurationSection> configurations) {
         resolvingKeys.clear();
         return resolveConfiguration(key, properties, configurations, resolvingKeys);
     }
 
+    @Nullable
     protected ConfigurationSection resolveConfiguration(String key, ConfigurationSection properties, Map<String, ConfigurationSection> configurations, Set<String> resolving) {
         // Catch circular dependencies
         if (resolvingKeys.contains(key)) {
@@ -3719,7 +3743,7 @@ public class MagicController implements MageController {
         return wandTemplates.keySet();
     }
 
-    public ConfigurationSection getWandTemplateConfiguration(String key) {
+    @Nullable public ConfigurationSection getWandTemplateConfiguration(String key) {
         WandTemplate template = getWandTemplate(key);
         return template == null ? null : template.getConfiguration();
     }
@@ -3764,9 +3788,9 @@ public class MagicController implements MageController {
 		return elementals.getElementalScale(entity);
 	}
 
-	@Override
-	public com.elmakers.mine.bukkit.api.spell.SpellCategory getCategory(String key) 
-	{
+    @Nullable
+    @Override
+    public com.elmakers.mine.bukkit.api.spell.SpellCategory getCategory(String key) {
         if (key == null || key.isEmpty()) {
             return null;
         }
@@ -3806,10 +3830,10 @@ public class MagicController implements MageController {
         return allSpells;
     }
 
+    @Nullable
     @Override
-	public SpellTemplate getSpellTemplate(String name) 
-	{
-		if (name == null || name.length() == 0) return null;
+    public SpellTemplate getSpellTemplate(String name) {
+        if (name == null || name.length() == 0) return null;
         SpellTemplate spell = spellAliases.get(name);
         if (spell == null) {
             spell = spells.get(name);
@@ -4121,6 +4145,7 @@ public class MagicController implements MageController {
         return Wand.isSkill(item);
     }
 
+    @Nullable
     @Override
     public String getWandKey(ItemStack item) {
         if (Wand.isWand(item)) {
@@ -4161,11 +4186,13 @@ public class MagicController implements MageController {
         return material.getKey();
     }
 
+    @Nullable
     @Override
     public ItemStack createItem(String magicItemKey) {
         return createItem(magicItemKey, false);
     }
 
+    @Nullable
     @Override
     public ItemStack createItem(String magicItemKey, boolean brief) {
         ItemStack itemStack = null;
@@ -4277,6 +4304,7 @@ public class MagicController implements MageController {
         return itemStack;
     }
 
+    @Nullable
     @Override
     public ItemStack createGenericItem(String key) {
         ConfigurationSection template = getWandTemplateConfiguration(key);
@@ -4310,6 +4338,7 @@ public class MagicController implements MageController {
 
     @Override
     public com.elmakers.mine.bukkit.api.wand.Wand createUpgrade(String wandKey) {
+        // TODO: Potential NPE?
         Wand wand = Wand.createWand(this, wandKey);
         if (!wand.isUpgrade()) {
             wand.makeUpgrade();
@@ -4317,16 +4346,19 @@ public class MagicController implements MageController {
         return wand;
     }
 
+    @Nullable
     @Override
     public ItemStack createSpellItem(String spellKey) {
         return Wand.createSpellItem(spellKey, this, null, true);
     }
 
+    @Nullable
     @Override
     public ItemStack createSpellItem(String spellKey, boolean brief) {
         return Wand.createSpellItem(spellKey, this, null, !brief);
     }
 
+    @Nullable
     @Override
     public ItemStack createBrushItem(String brushKey) {
         return Wand.createBrushItem(brushKey, this, null, true);
@@ -4376,14 +4408,15 @@ public class MagicController implements MageController {
         return WandUpgradePath.getPathKeys();
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.wand.WandUpgradePath getPath(String key) {
         return WandUpgradePath.getPath(key);
     }
 
+    @Nullable
     @Override
-    public ItemStack deserialize(ConfigurationSection root, String key)
-    {
+    public ItemStack deserialize(ConfigurationSection root, String key) {
         ConfigurationSection itemSection = root.getConfigurationSection(key);
         if (itemSection == null) {
             return null;
@@ -4463,7 +4496,7 @@ public class MagicController implements MageController {
         return heroesManager;
     }
 
-    public ManaController getManaController() {
+    @Nullable public ManaController getManaController() {
         if (useHeroesMana && heroesManager != null) return heroesManager;
         if (useSkillAPIMana && skillAPIManager != null) return skillAPIManager;
         return null;
@@ -4645,11 +4678,13 @@ public class MagicController implements MageController {
         return 0;
     }
 
+    @Nullable
     @Override
     public String getSpell(ItemStack item) {
         return Wand.getSpell(item);
     }
 
+    @Nullable
     @Override
     public String getSpellArgs(ItemStack item) {
         return Wand.getSpellArgs(item);
@@ -4660,6 +4695,7 @@ public class MagicController implements MageController {
         return mobs.getKeys();
     }
 
+    @Nullable
     @Override
     public Entity spawnMob(String key, Location location) {
         EntityData mobType = mobs.get(key);
@@ -4673,11 +4709,13 @@ public class MagicController implements MageController {
         return location.getWorld().spawnEntity(location, entityType);
     }
 
+    @Nullable
     @Override
     public EntityData getMob(String key) {
         return mobs.get(key);
     }
 
+    @Nullable
     @Override
     public EntityData getMobByName(String key) {
         return mobs.getByName(key);
@@ -4692,12 +4730,14 @@ public class MagicController implements MageController {
     public Set<String> getItemKeys() {
         return items.getKeys();
     }
-    
+
+    @Nullable
     @Override
     public ItemData getItem(String key) {
         return items.get(key);
     }
-    
+
+    @Nullable
     @Override
     public ItemData getOrCreateItem(String key) {
         if (key == null || key.isEmpty()) {
@@ -4705,7 +4745,8 @@ public class MagicController implements MageController {
         }
         return items.getOrCreate(key);
     }
-    
+
+    @Nullable
     @Override
     public ItemData getItem(ItemStack match) {
         return items.get(match);
@@ -4720,7 +4761,8 @@ public class MagicController implements MageController {
     public void loadItemTemplate(String key, ConfigurationSection configuration) {
         items.loadItem(key, configuration);
     }
-    
+
+    @Nullable
     @Override
     public Double getWorth(ItemStack item) {
         String spellKey = Wand.getSpell(item);
@@ -4745,6 +4787,7 @@ public class MagicController implements MageController {
         return backupInventories;
     }
 
+    @Nullable
     @Override
     public String getBlockSkin(Material blockType) {
         String skinName = null;
@@ -5000,6 +5043,7 @@ public class MagicController implements MageController {
         return true;
     }
 
+    @Nullable
     @Override
     public String getMobSkin(EntityType mobType)
     {
@@ -5091,6 +5135,7 @@ public class MagicController implements MageController {
         worldGuardManager.initializeFlags(plugin);
     }
 
+    @Nullable
     @Override
     public Object getWandProperty(ItemStack item, String key) {
         Preconditions.checkNotNull(key, "key");

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicPlugin.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicPlugin.java
@@ -27,6 +27,10 @@ import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
 import com.elmakers.mine.bukkit.utility.NMSUtils;
 import com.elmakers.mine.bukkit.wand.Wand;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -39,10 +43,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.logging.Level;
 
 /*! \mainpage Magic Bukkit Plugin
 *
@@ -343,6 +343,7 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
 		return Wand.isWand(item);
 	}
 
+    @Nullable
     @Override
     public String getSpell(ItemStack item) {
         return Wand.getSpell(item);
@@ -358,6 +359,7 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
         return Wand.isSpell(item);
     }
 
+    @Nullable
     @Override
     public String getBrush(ItemStack item) {
         return Wand.getBrush(item);
@@ -408,11 +410,13 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
         return controller.hasItem(player, item);
     }
 
+    @Nullable
     @Override
     public ItemStack createItem(String magicKey) {
         return createItem(magicKey, null);
     }
 
+    @Nullable
     @Override
     public ItemStack createItem(String magicKey, com.elmakers.mine.bukkit.api.magic.Mage mage) {
         ItemStack itemStack = null;
@@ -431,15 +435,17 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
         return controller.createItem(magicKey);
     }
 
+    @Nullable
     @Override
     public ItemStack createGenericItem(String itemKey) {
         return controller.createItem(itemKey);
     }
 
+    @Nullable
     @Override
-	public com.elmakers.mine.bukkit.api.wand.Wand createWand(String wandKey) {
-		return Wand.createWand(controller, wandKey);
-	}
+    public com.elmakers.mine.bukkit.api.wand.Wand createWand(String wandKey) {
+        return Wand.createWand(controller, wandKey);
+    }
 
     @Override
     public com.elmakers.mine.bukkit.api.wand.Wand createUpgrade(String wandKey) {
@@ -455,15 +461,17 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
         return controller.getItemKey(item);
     }
 
-	@Override
-	public ItemStack createSpellItem(String spellKey) {
-		return Wand.createSpellItem(spellKey, controller, null, true);
-	}
+    @Nullable
+    @Override
+    public ItemStack createSpellItem(String spellKey) {
+        return Wand.createSpellItem(spellKey, controller, null, true);
+    }
 
-	@Override
-	public ItemStack createBrushItem(String brushKey) {
-		return Wand.createBrushItem(brushKey, controller, null, true);
-	}
+    @Nullable
+    @Override
+    public ItemStack createBrushItem(String brushKey) {
+        return Wand.createBrushItem(brushKey, controller, null, true);
+    }
 
 	@Override
 	public boolean cast(String spellName, String[] parameters) {
@@ -510,15 +518,17 @@ public class MagicPlugin extends JavaPlugin implements MagicAPI
 		return new Wand(controller, iconMaterial, iconData);
 	}
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.wand.Wand createWand(ItemStack item) {
         return Wand.createWand(controller, item);
     }
 
-	@Override
-	public SpellTemplate getSpellTemplate(String key) {
-		return controller.getSpellTemplate(key);
-	}
+    @Nullable
+    @Override
+    public SpellTemplate getSpellTemplate(String key) {
+        return controller.getSpellTemplate(key);
+    }
 
 	@Override
 	public Collection<String> getSchematicNames() {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MaterialSets.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MaterialSets.java
@@ -25,7 +25,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class MaterialSets {
     @Nullable
     public static Set<Material> toLegacy(@Nullable MaterialSet v) {
-        return v == null ? null : ImmutableSet.copyOf(v.getMaterials());
+        return v == null ? null : toLegacyNN(v);
+    }
+
+    @Nonnull
+    public static Set<Material> toLegacyNN(@Nonnull MaterialSet v) {
+        return ImmutableSet.copyOf(v.getMaterials());
     }
 
     private static enum WildcardMaterialSet implements MaterialSet {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/ParameterizedConfiguration.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/ParameterizedConfiguration.java
@@ -2,12 +2,12 @@ package com.elmakers.mine.bukkit.magic;
 
 import de.slikey.effectlib.math.EquationStore;
 import de.slikey.effectlib.math.EquationTransform;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationOptions;
 import org.bukkit.configuration.ConfigurationSection;
-
-import java.util.Map;
-import java.util.Set;
 
 public abstract class ParameterizedConfiguration extends ParameterizedConfigurationSection implements Configuration {
     private static class Options extends ConfigurationOptions {
@@ -17,7 +17,8 @@ public abstract class ParameterizedConfiguration extends ParameterizedConfigurat
     }
     
     private Options options;
-    
+
+    @Nullable
     @Override
     public ConfigurationSection getParent() {
         return null;
@@ -38,6 +39,7 @@ public abstract class ParameterizedConfiguration extends ParameterizedConfigurat
 
     }
 
+    @Nullable
     @Override
     public Configuration getDefaults() {
         return null;
@@ -52,6 +54,7 @@ public abstract class ParameterizedConfiguration extends ParameterizedConfigurat
         return options;
     }
 
+    @Nullable
     protected Double evaluate(String expression) {
         Set<String> parameters = getParameters();
         if (parameters == null || parameters.isEmpty()) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/SimpleMaterialSetManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/SimpleMaterialSetManager.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
         return getMaterialSet(name, MaterialSets.empty());
     }
 
+    @Nullable
     @Override
     public MaterialSet fromConfig(String name) {
         if (name == null || name.isEmpty()) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/SourceLocation.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/SourceLocation.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
 
+import javax.annotation.Nullable;
+
 public class SourceLocation {
     private LocationType locationType;
     private boolean orientToTarget;
@@ -82,6 +84,7 @@ public class SourceLocation {
         }
     }
 
+    @Nullable
     public Location getLocation(CastContext context) {
         Mage mage;
         Location eyeLocation;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/TemplatedProperties.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/TemplatedProperties.java
@@ -7,10 +7,11 @@ import org.bukkit.configuration.ConfigurationSection;
 import javax.annotation.Nullable;
 
 public abstract class TemplatedProperties extends CasterProperties {
-     public TemplatedProperties(MagicPropertyType type, MageController controller) {
+    public TemplatedProperties(MagicPropertyType type, MageController controller) {
         super(type, controller);
     }
 
+    @Nullable
     @Override
     public ConfigurationSection getConfigurationSection(String key) {
         ConfigurationSection own = super.getConfigurationSection(key);
@@ -27,5 +28,6 @@ public abstract class TemplatedProperties extends CasterProperties {
         return own;
     }
 
-    protected abstract @Nullable BaseMagicProperties getTemplate();
+    @Nullable
+    protected abstract BaseMagicProperties getTemplate();
 }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicItemCommandExecutor.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicItemCommandExecutor.java
@@ -27,7 +27,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/WandCommandExecutor.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/WandCommandExecutor.java
@@ -1,5 +1,21 @@
 package com.elmakers.mine.bukkit.magic.command;
 
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.MageController;
+import com.elmakers.mine.bukkit.api.magic.MagicAPI;
+import com.elmakers.mine.bukkit.api.spell.Spell;
+import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
+import com.elmakers.mine.bukkit.api.wand.Wand;
+import com.elmakers.mine.bukkit.api.wand.WandAction;
+import com.elmakers.mine.bukkit.api.wand.WandTemplate;
+import com.elmakers.mine.bukkit.block.MaterialAndData;
+import com.elmakers.mine.bukkit.block.MaterialBrush;
+import com.elmakers.mine.bukkit.magic.BaseMagicProperties;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
+import com.elmakers.mine.bukkit.utility.InventoryUtils;
+import com.elmakers.mine.bukkit.wand.WandMode;
+import de.slikey.effectlib.util.ParticleEffect;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -8,18 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
-import com.elmakers.mine.bukkit.api.magic.MageController;
-import com.elmakers.mine.bukkit.block.MaterialAndData;
-import com.elmakers.mine.bukkit.magic.BaseMagicProperties;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
-import com.elmakers.mine.bukkit.api.wand.WandTemplate;
-import com.elmakers.mine.bukkit.utility.InventoryUtils;
-import com.elmakers.mine.bukkit.api.wand.WandAction;
-import com.elmakers.mine.bukkit.wand.WandMode;
-
-import de.slikey.effectlib.util.ParticleEffect;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -30,13 +35,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.api.magic.MagicAPI;
-import com.elmakers.mine.bukkit.api.spell.Spell;
-import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
-import com.elmakers.mine.bukkit.api.wand.Wand;
-import com.elmakers.mine.bukkit.block.MaterialBrush;
 
 public class WandCommandExecutor extends MagicConfigurableExecutor {
 	
@@ -884,24 +882,24 @@ public class WandCommandExecutor extends MagicConfigurableExecutor {
 		}
 		return result;
 	}
-	
-	protected Wand checkWand(CommandSender sender, Player player)
-	{
-		return checkWand(sender, player, false, false);
-	}
-	
-	protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable)
-	{
-		return checkWand(sender, player, skipModifiable, false);
-	}
-	
-	protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable, boolean skipBound)
-	{
-		return checkWand(sender, player, skipModifiable, skipBound, false);
-	}
-	
-	protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable, boolean skipBound, boolean quiet)
-	{
+
+    @Nullable
+    protected Wand checkWand(CommandSender sender, Player player) {
+        return checkWand(sender, player, false, false);
+    }
+
+    @Nullable
+    protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable) {
+        return checkWand(sender, player, skipModifiable, false);
+    }
+
+    @Nullable
+    protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable, boolean skipBound) {
+        return checkWand(sender, player, skipModifiable, skipBound, false);
+    }
+
+    @Nullable
+    protected Wand checkWand(CommandSender sender, Player player, boolean skipModifiable, boolean skipBound, boolean quiet) {
 		Mage mage = api.getMage(player);
 		if (mage == null) return  null;
 		Wand wand = mage.getActiveWand();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/ExplosionController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/ExplosionController.java
@@ -18,6 +18,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 public class ExplosionController implements Listener {
     private final MagicController controller;
     private int	maxTNTPerChunk = 0;
@@ -47,6 +49,7 @@ public class ExplosionController implements Listener {
         }
     }
 
+    @Nullable
     protected UndoList getExplosionUndo(Entity explodingEntity) {
         UndoList blockList = controller.getEntityUndo(explodingEntity);
         if (blockList == null && autoRollbackDuration > 0 && rollbackExplosions.contains(explodingEntity.getType())) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/ItemController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/ItemController.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 public class ItemController {
     private MageController controller;
     private final Map<String, ItemData> items = new HashMap<>();
@@ -48,11 +50,13 @@ public class ItemController {
     public Set<String> getKeys() {
         return items.keySet();
     }
-    
+
+    @Nullable
     public ItemData get(String key) {
         return items.get(key);
     }
 
+    @Nullable
     public ItemData getOrCreate(String key) {
         ItemData data = get(key);
         if (data == null) {
@@ -65,6 +69,7 @@ public class ItemController {
         return data;
     }
 
+    @Nullable
     public ItemData get(ItemStack item) {
         return itemsByStack.get(item);
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/MobController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/MobController.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 public class MobController implements Listener {
     private MageController controller;
     private final Map<String, EntityData> mobs = new HashMap<>();
@@ -133,11 +135,13 @@ public class MobController implements Listener {
     public Set<String> getKeys() {
         return mobs.keySet();
     }
-    
+
+    @Nullable
     public EntityData get(String key) {
         return mobs.get(key);
     }
 
+    @Nullable
     public EntityData getByName(String name) {
         return mobsByName.get(name);
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/maps/BufferedMapCanvas.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/maps/BufferedMapCanvas.java
@@ -1,10 +1,10 @@
 package com.elmakers.mine.bukkit.maps;
 
+import com.elmakers.mine.bukkit.utility.ColorHD;
 import java.awt.Image;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.elmakers.mine.bukkit.utility.ColorHD;
+import javax.annotation.Nullable;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.map.MapCanvas;
@@ -31,6 +31,7 @@ public class BufferedMapCanvas implements MapCanvas {
     private byte[] pixels = new byte[128 * 128];
     private Map<Byte, DyeColor> dyeColors = new HashMap<>();
 
+    @Nullable
     @Override
     public MapView getMapView() {
         return null;
@@ -82,7 +83,7 @@ public class BufferedMapCanvas implements MapCanvas {
         return pixels[x + y * CANVAS_WIDTH];
     }
 
-    @SuppressWarnings("deprecation")
+    @Nullable @SuppressWarnings("deprecation")
     public DyeColor getDyeColor(int x, int y) {
         byte color = getPixel(x, y);
         if (color == MapPalette.TRANSPARENT) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/maps/MapController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/maps/MapController.java
@@ -1,6 +1,13 @@
 package com.elmakers.mine.bukkit.maps;
 
 import com.elmakers.mine.bukkit.utility.SkinUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -11,13 +18,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.map.MapView;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
 
 public class MapController implements com.elmakers.mine.bukkit.api.maps.MapController {
     private final File configurationFile;
@@ -281,6 +281,7 @@ public class MapController implements com.elmakers.mine.bukkit.api.maps.MapContr
      * @param photoLabel
      * @return
      */
+    @Nullable
     @Override
     public ItemStack getPlayerPortrait(String worldName, String playerName, Integer priority, String photoLabel) {
         photoLabel = photoLabel == null ? playerName : photoLabel;
@@ -293,11 +294,13 @@ public class MapController implements com.elmakers.mine.bukkit.api.maps.MapContr
         return getMapItem(photoLabel, mapView);
     }
 
+    @Nullable
     public MapView getURL(String worldName, String url, String name, int x, int y, Integer xOverlay, Integer yOverlay, int width, int height, Integer priority) {
         URLMap map = get(worldName, url, name, x, y, xOverlay, yOverlay, width, height, priority);
         return map.getMapView();
     }
 
+    @Nullable
     public MapView getURL(String worldName, String url, String name, int x, int y, Integer xOverlay, Integer yOverlay, int width, int height, Integer priority, String playerName) {
         URLMap map = get(worldName, url, name, x, y, xOverlay, yOverlay, width, height, priority, playerName);
         return map.getMapView();
@@ -436,14 +439,17 @@ public class MapController implements com.elmakers.mine.bukkit.api.maps.MapContr
         return map;
     }
 
+    @Nullable
     private URLMap get(String worldName, String url, int x, int y, int width, int height) {
         return get(worldName, url, x, y, width, height, null);
     }
 
+    @Nullable
     private URLMap get(String worldName, String url, String name, int x, int y, Integer xOverlay, Integer yOverlay, int width, int height, Integer priority) {
         return get(worldName, url, name, x, y, xOverlay, yOverlay, width, height, priority, null);
     }
 
+    @Nullable
     @SuppressWarnings("deprecation")
     private URLMap get(String worldName, String url, String name, int x, int y, Integer xOverlay, Integer yOverlay, int width, int height, Integer priority, String playerName) {
         URLMap existing = null;
@@ -475,6 +481,7 @@ public class MapController implements com.elmakers.mine.bukkit.api.maps.MapContr
         return newMap;
     }
 
+    @Nullable
     private URLMap get(String worldName, String url, int x, int y, int width, int height, Integer priority) {
         return get(worldName, url, null, x, y, null, null, width, height, priority);
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/maps/URLMap.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/maps/URLMap.java
@@ -1,5 +1,6 @@
 package com.elmakers.mine.bukkit.maps;
 
+import com.elmakers.mine.bukkit.utility.SkinUtils;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
@@ -17,14 +18,12 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.ImageInputStream;
-
-import com.elmakers.mine.bukkit.utility.SkinUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -180,6 +179,7 @@ public class URLMap extends MapRenderer implements com.elmakers.mine.bukkit.api.
         return enabled;
     }
 
+    @Nullable
     @SuppressWarnings("deprecation")
     protected MapView getMapView() {
         if (!enabled) {
@@ -349,7 +349,7 @@ public class URLMap extends MapRenderer implements com.elmakers.mine.bukkit.api.
         }
     }
 
-    protected BufferedImage getImage() {
+    @Nullable protected BufferedImage getImage() {
         if (loading || !enabled) {
             return null;
         }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/PreciousStonesAPI.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/PreciousStonesAPI.java
@@ -2,7 +2,11 @@ package com.elmakers.mine.bukkit.protection;
 
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
 import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
-
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import net.sacredlabyrinth.Phaed.PreciousStones.PreciousStones;
 import net.sacredlabyrinth.Phaed.PreciousStones.entries.FieldSign;
 import net.sacredlabyrinth.Phaed.PreciousStones.field.Field;
@@ -25,11 +29,6 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class PreciousStonesAPI implements BlockBuildManager, BlockBreakManager, PVPManager {
 	private PreciousStones preciousStones = null;
@@ -61,7 +60,7 @@ public class PreciousStonesAPI implements BlockBuildManager, BlockBreakManager, 
 		return fields.size() == 0;
 	}
 
-	public Map<String, Location> getFieldLocations(Player player) {
+	@Nullable public Map<String, Location> getFieldLocations(Player player) {
 		if (preciousStones == null || player == null || !canGetFields)
 			return null;
 
@@ -110,7 +109,7 @@ public class PreciousStonesAPI implements BlockBuildManager, BlockBreakManager, 
 		return allowed;
 	}
 
-    public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
+    @Nullable public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
         Boolean overridePermission = null;
         if (location != null && preciousStones != null)
         {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/PreciousStonesManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/PreciousStonesManager.java
@@ -1,13 +1,13 @@
 package com.elmakers.mine.bukkit.protection;
 
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.util.Map;
 
 public class PreciousStonesManager implements BlockBuildManager, BlockBreakManager, PVPManager {
 	private boolean enabled = false;
@@ -60,6 +60,7 @@ public class PreciousStonesManager implements BlockBuildManager, BlockBreakManag
 		return api.hasBuildPermission(player, block);
 	}
 
+    @Nullable
     public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
 		if (!override || !enabled || api == null || location == null)
 		{
@@ -96,6 +97,7 @@ public class PreciousStonesManager implements BlockBuildManager, BlockBreakManag
 		return api.rentField(signLocation, player, rent, timePeriod, signDirection);
 	}
 
+	@Nullable
 	public Map<String, Location> getFieldLocations(Player player) {
 		if (!enabled || api == null || player == null)
 			return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/TownyAPI.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/TownyAPI.java
@@ -16,16 +16,16 @@ import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
+import java.lang.reflect.Method;
+import java.util.UUID;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.lang.reflect.Method;
-import java.util.UUID;
-import java.util.logging.Level;
 
 public class TownyAPI
 {
@@ -115,7 +115,7 @@ public class TownyAPI
         return true;
     }
 
-    protected Resident getResident(Player player) {
+    @Nullable protected Resident getResident(Player player) {
         try {
             if (getPlayerByNameMethod != null) {
                 return (Resident) getPlayerByNameMethod.invoke(TownyUniverse.getDataSource(), player.getName());
@@ -131,7 +131,7 @@ public class TownyAPI
         return null;
     }
 
-    public Location getTownLocation(Player player) {
+    @Nullable public Location getTownLocation(Player player) {
         if (towny == null || player == null) {
             return null;
         }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/TownyManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/TownyManager.java
@@ -1,12 +1,12 @@
 package com.elmakers.mine.bukkit.protection;
 
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.util.logging.Level;
 
 public class TownyManager implements PVPManager, BlockBreakManager, BlockBuildManager {
 	private boolean enabled = false;
@@ -80,7 +80,7 @@ public class TownyManager implements PVPManager, BlockBreakManager, BlockBuildMa
 		return towny.canTarget(entity, target);
 	}
 
-	public Location getTownLocation(Player player) {
+	@Nullable public Location getTownLocation(Player player) {
 		if (!enabled || towny == null || player == null)
 			return null;
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WGCustomFlagsManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WGCustomFlagsManager.java
@@ -8,10 +8,9 @@ import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.SetFlag;
 import com.sk89q.worldguard.protection.flags.StringFlag;
-
-import org.bukkit.plugin.Plugin;
-
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.bukkit.plugin.Plugin;
 
 public class WGCustomFlagsManager implements WorldGuardFlags {
 
@@ -40,24 +39,25 @@ public class WGCustomFlagsManager implements WorldGuardFlags {
         customFlags.addCustomFlag(REFLECTIVE);
     }
 
+    @Nullable
     @Override
-    public String getDestructible(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public String getDestructible(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, DESTRUCTIBLE);
     }
 
+    @Nullable
     @Override
-    public String getReflective(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public String getReflective(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, REFLECTIVE);
     }
 
+    @Nullable
     @Override
-    public Set<String> getSpellOverrides(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public Set<String> getSpellOverrides(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, SPELL_OVERRIDES);
     }
 
+    @Nullable
     @Override
     public Boolean getWandPermission(RegionAssociable source, ApplicableRegionSet checkSet, Wand wand) {
         String wandTemplate = wand.getTemplateKey();
@@ -72,6 +72,7 @@ public class WGCustomFlagsManager implements WorldGuardFlags {
         return null;
     }
 
+    @Nullable
     @Override
     public Boolean getCastPermission(RegionAssociable source, ApplicableRegionSet checkSet, SpellTemplate spell) {
         String spellKey = spell.getSpellKey().getBaseKey();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardAPI.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardAPI.java
@@ -11,13 +11,13 @@ import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import java.util.Set;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.util.Set;
-import java.util.logging.Level;
 
 public class WorldGuardAPI {
     private final Plugin owningPlugin;
@@ -106,7 +106,7 @@ public class WorldGuardAPI {
 		return true;
 	}
 
-    public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
+    @Nullable public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
         if (location != null && worldGuard != null && customFlags != null)
         {
             RegionManager regionManager = worldGuard.getRegionManager(location.getWorld());
@@ -124,7 +124,7 @@ public class WorldGuardAPI {
         return null;
     }
 
-    public Boolean getWandPermission(Player player, Wand wand, Location location) {
+    @Nullable public Boolean getWandPermission(Player player, Wand wand, Location location) {
         if (location != null && worldGuard != null && customFlags != null)
         {
             RegionManager regionManager = worldGuard.getRegionManager(location.getWorld());
@@ -142,7 +142,7 @@ public class WorldGuardAPI {
         return null;
     }
 
-    public String getReflective(Player player, Location location) {
+    @Nullable public String getReflective(Player player, Location location) {
         if (location != null && worldGuard != null && customFlags != null)
         {
             RegionManager regionManager = worldGuard.getRegionManager(location.getWorld());
@@ -160,7 +160,7 @@ public class WorldGuardAPI {
         return null;
     }
 
-    public Set<String> getSpellOverrides(Player player, Location location) {
+    @Nullable public Set<String> getSpellOverrides(Player player, Location location) {
         if (location != null && worldGuard != null && customFlags != null)
         {
             RegionManager regionManager = worldGuard.getRegionManager(location.getWorld());
@@ -178,7 +178,7 @@ public class WorldGuardAPI {
         return null;
     }
 
-    public String getDestructible(Player player, Location location) {
+    @Nullable public String getDestructible(Player player, Location location) {
         if (location != null && worldGuard != null && customFlags != null)
         {
             RegionManager regionManager = worldGuard.getRegionManager(location.getWorld());

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardFlags.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardFlags.java
@@ -7,10 +7,21 @@ import com.sk89q.worldguard.protection.association.RegionAssociable;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 public interface WorldGuardFlags {
+    @Nullable
     public String getDestructible(RegionAssociable source, ApplicableRegionSet checkSet);
+
+    @Nullable
     public String getReflective(RegionAssociable source, ApplicableRegionSet checkSet);
+
+    @Nullable
     public Set<String> getSpellOverrides(RegionAssociable source, ApplicableRegionSet checkSet);
+
+    @Nullable
     public Boolean getWandPermission(RegionAssociable source, ApplicableRegionSet checkSet, Wand wand);
+
+    @Nullable
     public Boolean getCastPermission(RegionAssociable source, ApplicableRegionSet checkSet, SpellTemplate spell);
 }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardFlagsManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardFlagsManager.java
@@ -8,11 +8,10 @@ import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.SetFlag;
 import com.sk89q.worldguard.protection.flags.StringFlag;
-
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
-import org.bukkit.plugin.Plugin;
-
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.bukkit.plugin.Plugin;
 
 public class WorldGuardFlagsManager implements WorldGuardFlags {
 
@@ -43,24 +42,25 @@ public class WorldGuardFlagsManager implements WorldGuardFlags {
         callingPlugin.getLogger().info("Registered custom WorldGuard flags: allowed-spells, blocked-spells, allowed-spell-categories, blocked-spell-categories, allowed-wands, blocked-wands, spell-overrides, destructible, reflective");
     }
 
+    @Nullable
     @Override
-    public String getDestructible(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public String getDestructible(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, DESTRUCTIBLE);
     }
 
+    @Nullable
     @Override
-    public String getReflective(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public String getReflective(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, REFLECTIVE);
     }
 
+    @Nullable
     @Override
-    public Set<String> getSpellOverrides(RegionAssociable source, ApplicableRegionSet checkSet)
-    {
+    public Set<String> getSpellOverrides(RegionAssociable source, ApplicableRegionSet checkSet) {
         return checkSet.queryValue(source, SPELL_OVERRIDES);
     }
 
+    @Nullable
     @Override
     public Boolean getWandPermission(RegionAssociable source, ApplicableRegionSet checkSet, Wand wand) {
         String wandTemplate = wand.getTemplateKey();
@@ -75,6 +75,7 @@ public class WorldGuardFlagsManager implements WorldGuardFlags {
         return null;
     }
 
+    @Nullable
     @Override
     public Boolean getCastPermission(RegionAssociable source, ApplicableRegionSet checkSet, SpellTemplate spell) {
         String spellKey = spell.getSpellKey().getBaseKey();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/WorldGuardManager.java
@@ -2,14 +2,14 @@ package com.elmakers.mine.bukkit.protection;
 
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
 import com.elmakers.mine.bukkit.api.wand.Wand;
+import java.util.Set;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import java.util.Set;
-import java.util.logging.Level;
 
 public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBuildManager {
     private boolean enabled = false;
@@ -75,6 +75,7 @@ public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBu
         return true;
     }
 
+    @Nullable
     public Boolean getCastPermission(Player player, SpellTemplate spell, Location location) {
         if (enabled && worldGuard != null) {
             return worldGuard.getCastPermission(player, spell, location);
@@ -82,6 +83,7 @@ public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBu
         return null;
     }
 
+    @Nullable
     public Boolean getWandPermission(Player player, Wand wand, Location location) {
         if (enabled && worldGuard != null) {
             return worldGuard.getWandPermission(player, wand, location);
@@ -89,6 +91,7 @@ public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBu
         return null;
     }
 
+    @Nullable
     public String getReflective(Player player, Location location) {
         if (enabled && worldGuard != null) {
             return worldGuard.getReflective(player, location);
@@ -96,6 +99,7 @@ public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBu
         return null;
     }
 
+    @Nullable
     public String getDestructible(Player player, Location location) {
         if (enabled && worldGuard != null) {
             return worldGuard.getDestructible(player, location);
@@ -103,6 +107,7 @@ public class WorldGuardManager implements PVPManager, BlockBreakManager, BlockBu
         return null;
     }
 
+    @Nullable
     public Set<String> getSpellOverrides(Player player, Location location) {
         if (enabled && worldGuard != null) {
             return worldGuard.getSpellOverrides(player, location);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/requirements/MagicRequirement.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/requirements/MagicRequirement.java
@@ -91,7 +91,7 @@ public  class MagicRequirement {
         }
     }
         
-    private List<PropertyRequirement> parsePropertyRequirements(ConfigurationSection configuration, String section, String type) {
+    @Nullable private List<PropertyRequirement> parsePropertyRequirements(ConfigurationSection configuration, String section, String type) {
         if (!configuration.contains(section)) return null;
 
         List<PropertyRequirement> requirements = new ArrayList<>();
@@ -344,7 +344,7 @@ public  class MagicRequirement {
         return null;
     }
 
-    protected String getRequiredProperty(CastContext context, CasterProperties properties, List<PropertyRequirement> requirements) {
+    @Nullable protected String getRequiredProperty(CastContext context, CasterProperties properties, List<PropertyRequirement> requirements) {
         for (PropertyRequirement requirement : requirements) {
             String key = requirement.key;
             Double value = properties.hasProperty(key) ? properties.getProperty(key, 0.0) : null;
@@ -361,7 +361,7 @@ public  class MagicRequirement {
         return null;
     }
 
-    protected String checkRequiredProperty(CastContext context, PropertyRequirement requirement, String name, Double value) {
+    @Nullable protected String checkRequiredProperty(CastContext context, PropertyRequirement requirement, String name, Double value) {
         if (requirement.value != null && (value == null || !value.equals(requirement.value))) {
             return getMessage(context, "property_requirement")
                 .replace("$property", name).replace("$value", Double.toString(requirement.value));

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/ActionSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/ActionSpell.java
@@ -5,12 +5,12 @@ import com.elmakers.mine.bukkit.api.batch.Batch;
 import com.elmakers.mine.bukkit.api.batch.SpellBatch;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-import org.bukkit.configuration.ConfigurationSection;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
+import javax.annotation.Nullable;
+import org.bukkit.configuration.ConfigurationSection;
 
 public class ActionSpell extends BrushSpell
 {
@@ -266,6 +266,7 @@ public class ActionSpell extends BrushSpell
         return requiresBreakPermission || (requiresBuildPermission && brushIsErase());
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.block.MaterialAndData getEffectMaterial()
     {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
@@ -15,6 +15,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 import com.elmakers.mine.bukkit.action.CastContext;
 import com.elmakers.mine.bukkit.api.batch.Batch;
 import com.elmakers.mine.bukkit.api.batch.SpellBatch;
@@ -386,25 +388,25 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return isSafeLocation(loc.getBlock());
     }
 
-    public Location tryFindPlaceToStand(Location targetLoc)
-    {
+    @Nullable
+    public Location tryFindPlaceToStand(Location targetLoc) {
         int maxHeight = CompatibilityUtils.getMaxHeight(targetLoc.getWorld());
         return tryFindPlaceToStand(targetLoc, maxHeight, maxHeight);
     }
 
-    public Location findPlaceToStand(Location targetLoc)
-    {
+    @Nullable
+    public Location findPlaceToStand(Location targetLoc) {
         return findPlaceToStand(targetLoc, verticalSearchDistance, verticalSearchDistance);
     }
 
-    public Location tryFindPlaceToStand(Location targetLoc, int maxDownDelta, int maxUpDelta)
-    {
+    @Nullable
+    public Location tryFindPlaceToStand(Location targetLoc, int maxDownDelta, int maxUpDelta) {
         Location location = findPlaceToStand(targetLoc, maxDownDelta, maxUpDelta);
         return location == null ? targetLoc : location;
     }
 
-    public Location findPlaceToStand(Location targetLoc, int maxDownDelta, int maxUpDelta)
-    {
+    @Nullable
+    public Location findPlaceToStand(Location targetLoc, int maxDownDelta, int maxUpDelta) {
         if (!targetLoc.getBlock().getChunk().isLoaded()) return null;
         int minY = MIN_Y;
         int maxY = CompatibilityUtils.getMaxHeight(targetLoc.getWorld());
@@ -446,13 +448,13 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return location;
     }
 
-    public Location findPlaceToStand(Location target, boolean goUp)
-    {
+    @Nullable
+    public Location findPlaceToStand(Location target, boolean goUp) {
         return findPlaceToStand(target, goUp, verticalSearchDistance);
     }
 
-    public Location findPlaceToStand(Location target, boolean goUp, int maxDelta)
-    {
+    @Nullable
+    public Location findPlaceToStand(Location target, boolean goUp, int maxDelta) {
         int direction = goUp ? 1 : -1;
 
         // search for a spot to stand
@@ -505,8 +507,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
      *
      * @return The Block the player is standing on
      */
-    public Block getPlayerBlock()
-    {
+    @Nullable
+    public Block getPlayerBlock() {
         Location location = getLocation();
         if (location == null) return null;
         return location.getBlock().getRelative(BlockFace.DOWN);
@@ -597,6 +599,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Location getLocation()
     {
         if (location != null) return location.clone();
@@ -606,8 +609,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return null;
     }
 
-    public Location getWandLocation()
-    {
+    @Nullable
+    public Location getWandLocation() {
         if (this.location != null)
         {
             return location.clone();
@@ -615,8 +618,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return mage.getWandLocation();
     }
 
-    public Location getCastLocation()
-    {
+    @Nullable
+    public Location getCastLocation() {
         if (this.location != null)
         {
             return location.clone();
@@ -657,8 +660,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return direction.getY() < -LOOK_THRESHOLD_RADIANS;
     }
 
-    public World getWorld()
-    {
+    @Nullable
+    public World getWorld() {
         Location location = getLocation();
         if (location != null) return location.getWorld();
         return null;
@@ -677,13 +680,13 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return (playerBlock.getType() == Material.WATER || playerBlock.getType() == Material.STATIONARY_WATER);
     }
 
-    protected String getBlockSkin(Material blockType) 
-    {
+    @Nullable
+    protected String getBlockSkin(Material blockType) { 
         return controller.getBlockSkin(blockType);
     }
 
-    protected String getMobSkin(EntityType mobType)
-    {
+    @Nullable
+    protected String getMobSkin(EntityType mobType) {
         return controller.getMobSkin(mobType);
     }
 
@@ -808,6 +811,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         }
     }
 
+    @Nullable
     protected List<CastingCost> parseCosts(ConfigurationSection node) {
         if (node == null) {
             return null;
@@ -1626,6 +1630,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Location getTargetLocation() {
         return null;
     }
@@ -1656,10 +1661,12 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Entity getTargetEntity() {
         return null;
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.block.MaterialAndData getEffectMaterial()
     {
@@ -1827,8 +1834,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     //
 
     @Override
-    public Object clone()
-    {
+    @Nullable
+    public Object clone() {
         try
         {
             return super.clone();
@@ -1879,6 +1886,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     // Public API Implementation
     //
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.spell.Spell createSpell()
     {
@@ -2032,6 +2040,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Collection<CastingCost> getCosts() {
         if (costs == null) return null;
         List<CastingCost> copy = new ArrayList<>();
@@ -2040,6 +2049,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Collection<CastingCost> getActiveCosts() {
         if (activeCosts == null) return null;
         List<CastingCost> copy = new ArrayList<>();
@@ -2098,25 +2108,30 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         }
     }
 
+    @Nullable
     @Override
     public String getMageCooldownDescription() {
         return getCooldownDescription(controller.getMessages(), mageCooldown, mage, null);
     }
 
+    @Nullable
     public String getMageCooldownDescription(Mage mage, com.elmakers.mine.bukkit.api.wand.Wand wand) {
         return getCooldownDescription(controller.getMessages(), mageCooldown, mage, wand);
     }
 
+    @Nullable
     @Override
     public String getCooldownDescription() {
         return getCooldownDescription(
                 controller.getMessages(), getDisplayCooldown(),  mage, null);
     }
 
+    @Nullable
     public String getWarmupDescription() {
         return getTimeDescription(controller.getMessages(), warmup);
     }
 
+    @Nullable
     public String getCooldownDescription(Mage mage, com.elmakers.mine.bukkit.api.wand.Wand wand) {
         return getCooldownDescription(
                 controller.getMessages(), getDisplayCooldown(), mage, wand);
@@ -2130,6 +2145,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return displayCooldown != -1 ? displayCooldown : cooldown;
     }
 
+    @Nullable
     private String getTimeDescription(Messages messages, int time) {
         if (time > 0) {
             int timeInSeconds = time / 1000;
@@ -2160,6 +2176,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return null;
     }
 
+    @Nullable
     protected String getCooldownDescription(Messages messages, int cooldown, Mage mage, com.elmakers.mine.bukkit.api.wand.Wand wand) {
         CooldownReducer reducer = mageClass != null ? mageClass : (wand != null ? wand : mage);
         if (reducer != null) {
@@ -2183,6 +2200,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public CastingCost getRequiredCost() {
         if (!mage.isCostFree() && (mageClass == null || !mageClass.isCostFree()))
         {
@@ -2406,6 +2424,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public Color getColor()
     {
         if (color != null) return color;
@@ -2482,6 +2501,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
+    @Nullable
     public SpellTemplate getUpgrade() {
         if (requiredUpgradeCasts <= 0
                 && ((requiredUpgradePath == null || requiredUpgradePath.isEmpty())
@@ -2511,6 +2531,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return mage.getEntity();
     }
 
+    @Nullable
     @Override
     public String getEffectParticle() {
         if (particle == null) {
@@ -2519,6 +2540,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return particle;
     }
 
+    @Nullable
     @Override
     public Color getEffectColor() {
         if (color == null) {
@@ -2655,8 +2677,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
-    public com.elmakers.mine.bukkit.api.block.MaterialBrush getBrush()
-    {
+    @Nullable
+    public com.elmakers.mine.bukkit.api.block.MaterialBrush getBrush() {
         if (mage == null) {
             return null;
         }
@@ -2817,8 +2839,8 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
 
     @Override
-    public ConfigurationSection getHandlerParameters(String handlerKey)
-    {
+    @Nullable
+    public ConfigurationSection getHandlerParameters(String handlerKey) {
         return null;
     }
 
@@ -2850,6 +2872,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
     }
     
     @Override
+    @Nullable
     public String getDurationDescription(Messages messages) {
         String description = null;
         long effectiveDuration = this.getDuration();
@@ -2875,6 +2898,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
         return description;
     }
 
+    @Nullable
     @Override
     public Double getAttribute(String attributeKey) {
         Double data = mage.getAttribute(attributeKey);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/BrushSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/BrushSpell.java
@@ -1,20 +1,21 @@
 package com.elmakers.mine.bukkit.spell;
 
+import com.elmakers.mine.bukkit.block.MaterialBrush;
+import com.elmakers.mine.bukkit.utility.ColorHD;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import com.elmakers.mine.bukkit.utility.ColorHD;
+import javax.annotation.Nullable;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.util.Vector;
-
-import com.elmakers.mine.bukkit.block.MaterialBrush;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
 
 public abstract class BrushSpell extends BlockSpell {
 
@@ -132,6 +133,7 @@ public abstract class BrushSpell extends BlockSpell {
         return brushIsErase();
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.block.MaterialBrush getBrush()
     {
@@ -147,6 +149,7 @@ public abstract class BrushSpell extends BlockSpell {
         return super.getBrush();
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.block.MaterialAndData getEffectMaterial()
     {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/TargetingSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/TargetingSpell.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class TargetingSpell extends BaseSpell {
     // This differs from CompatibilityUtils.MAX_ENTITY_RANGE,
@@ -313,8 +314,8 @@ public abstract class TargetingSpell extends BaseSpell {
         return targeting.getOrCreateTarget(getEyeLocation());
     }
 
-    public Block getTargetBlock()
-    {
+    @Nullable
+    public Block getTargetBlock() {
         return getTarget().getBlock();
     }
 
@@ -423,6 +424,7 @@ public abstract class TargetingSpell extends BaseSpell {
         return targetThroughMaterials.testBlock(block);
     }
 
+    @Nullable
     public Block getInteractBlock() {
         Location location = getEyeLocation();
         if (location == null) return null;
@@ -639,6 +641,7 @@ public abstract class TargetingSpell extends BaseSpell {
     }
 
     @Override
+    @Nullable
     public Location getTargetLocation() {
         Target target = targeting.getTarget();
         if (target != null && target.isValid()) {
@@ -649,6 +652,7 @@ public abstract class TargetingSpell extends BaseSpell {
     }
 
     @Override
+    @Nullable
     public Entity getTargetEntity() {
         Target target = targeting.getTarget();
         if (target != null && target.isValid()) {
@@ -658,6 +662,7 @@ public abstract class TargetingSpell extends BaseSpell {
         return null;
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.block.MaterialAndData getEffectMaterial()
     {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/FamiliarSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/FamiliarSpell.java
@@ -1,13 +1,18 @@
 package com.elmakers.mine.bukkit.spell.builtin;
 
+import com.elmakers.mine.bukkit.api.spell.SpellEventType;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.elmakers.mine.bukkit.spell.UndoableSpell;
+import com.elmakers.mine.bukkit.utility.RandomUtils;
+import com.elmakers.mine.bukkit.utility.Target;
+import com.elmakers.mine.bukkit.utility.WeightedPair;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
-
-import com.elmakers.mine.bukkit.utility.RandomUtils;
-import com.elmakers.mine.bukkit.utility.WeightedPair;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -24,11 +29,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
-
-import com.elmakers.mine.bukkit.api.spell.SpellEventType;
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import com.elmakers.mine.bukkit.spell.UndoableSpell;
-import com.elmakers.mine.bukkit.utility.Target;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
 
@@ -71,7 +71,7 @@ public class FamiliarSpell extends UndoableSpell implements Listener
             List<LivingEntity> iterate = new ArrayList<>(familiars);
             for (LivingEntity familiar : iterate)
             {
-                if (familiar.getUniqueId() == entity.getUniqueId()) {
+                if (Objects.equals(familiar.getUniqueId(), entity.getUniqueId())) {
                     familiar.remove();
                     familiars.remove(familiar);
                 }
@@ -244,7 +244,7 @@ public class FamiliarSpell extends UndoableSpell implements Listener
 
 	}
 
-	protected LivingEntity spawnFamiliar(Location target, EntityType famType, Location targetLocation, LivingEntity targetEntity, boolean setTarget)
+	@Nullable protected LivingEntity spawnFamiliar(Location target, EntityType famType, Location targetLocation, LivingEntity targetEntity, boolean setTarget)
 	{
         LivingEntity familiar = null;
 		try {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/OcelotSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/OcelotSpell.java
@@ -1,16 +1,15 @@
 package com.elmakers.mine.bukkit.spell.builtin;
 
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.elmakers.mine.bukkit.spell.TargetingSpell;
+import com.elmakers.mine.bukkit.utility.Target;
 import java.util.ArrayList;
 import java.util.List;
-
+import javax.annotation.Nullable;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.*;
-
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import com.elmakers.mine.bukkit.spell.TargetingSpell;
-import com.elmakers.mine.bukkit.utility.Target;
 
 public class OcelotSpell extends TargetingSpell
 {
@@ -18,7 +17,7 @@ public class OcelotSpell extends TargetingSpell
 
 	protected List<Ocelot> ocelots = new ArrayList<>();
 
-	public Ocelot newOcelot(Target target)
+	@Nullable public Ocelot newOcelot(Target target)
 	{
 		Block targetBlock = target.getBlock();
 		if (targetBlock == null)

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/PhaseSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/PhaseSpell.java
@@ -1,15 +1,15 @@
 package com.elmakers.mine.bukkit.spell.builtin;
 
 import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.elmakers.mine.bukkit.spell.TargetingSpell;
 import com.elmakers.mine.bukkit.utility.Target;
+import javax.annotation.Nullable;
 import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.Plugin;
-
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import com.elmakers.mine.bukkit.spell.TargetingSpell;
 
 @Deprecated
 public class PhaseSpell extends TargetingSpell
@@ -103,7 +103,7 @@ public class PhaseSpell extends TargetingSpell
 		return SpellResult.CAST;
 	}
 
-    protected World getWorld(String worldName, boolean loadWorld) {
+    @Nullable protected World getWorld(String worldName, boolean loadWorld) {
         World world = Bukkit.getWorld(worldName);
         if (world == null) {
             if (loadWorld) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/RecallSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/RecallSpell.java
@@ -1,10 +1,15 @@
 package com.elmakers.mine.bukkit.spell.builtin;
 
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.elmakers.mine.bukkit.api.wand.LostWand;
+import com.elmakers.mine.bukkit.spell.UndoableSpell;
+import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+import com.elmakers.mine.bukkit.utility.Target;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-
+import javax.annotation.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -12,12 +17,6 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import com.elmakers.mine.bukkit.api.wand.LostWand;
-import com.elmakers.mine.bukkit.spell.UndoableSpell;
-import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
-import com.elmakers.mine.bukkit.utility.Target;
 
 @Deprecated
 public class RecallSpell extends UndoableSpell
@@ -290,7 +289,7 @@ public class RecallSpell extends UndoableSpell
 		cycleTargetType(reverse);
 	}
 	
-	protected Location getTargetLocation(Player player, RecallType type, int index) {
+	@Nullable protected Location getTargetLocation(Player player, RecallType type, int index) {
 		castMessage = "";
 		failMessage = "";
 		switch (type) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/WolfSpell.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/spell/builtin/WolfSpell.java
@@ -1,23 +1,22 @@
 package com.elmakers.mine.bukkit.spell.builtin;
 
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import com.elmakers.mine.bukkit.spell.TargetingSpell;
+import com.elmakers.mine.bukkit.utility.Target;
 import java.util.ArrayList;
 import java.util.List;
-
+import javax.annotation.Nullable;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.*;
-
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
-import com.elmakers.mine.bukkit.spell.TargetingSpell;
-import com.elmakers.mine.bukkit.utility.Target;
 
 public class WolfSpell extends TargetingSpell
 {
 	private static int DEFAULT_MAX_WOLVES = 5;
 	protected List<Wolf> wolves = new ArrayList<>();
 
-	public Wolf newWolf(Target target)
+	@Nullable public Wolf newWolf(Target target)
 	{
 		Block targetBlock = target.getBlock();
 		if (targetBlock == null) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/BoundingBox.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/BoundingBox.java
@@ -1,5 +1,6 @@
 package com.elmakers.mine.bukkit.utility;
 
+import javax.annotation.Nullable;
 import org.bukkit.util.Vector;
 
 public class BoundingBox
@@ -121,6 +122,7 @@ public class BoundingBox
         return true;
     }
 
+    @Nullable
     protected Vector getIntersection(double fDst1, double fDst2, Vector P1, Vector P2, int side) {
         if ((fDst1 * fDst2) >= 0.0f) return null;
         if (fDst1 == fDst2) return null;
@@ -136,8 +138,8 @@ public class BoundingBox
         return false;
     }
 
-    public Vector getIntersection(Vector p1, Vector p2)
-    {
+    @Nullable
+    public Vector getIntersection(Vector p1, Vector p2) {
         Vector currentHit = getIntersection(p1.getX() - min.getX(), p2.getX() - min.getX(), p1, p2, 1);
         Vector hit = getIntersection(p1.getY() - min.getY(), p2.getY() - min.getY(), p1, p2, 2);
         if (currentHit != null && hit != null) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
@@ -1,18 +1,18 @@
 package com.elmakers.mine.bukkit.utility;
 
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.spell.PrerequisiteSpell;
 import com.elmakers.mine.bukkit.api.spell.SpellKey;
+import com.elmakers.mine.bukkit.block.MaterialAndData;
 import com.elmakers.mine.bukkit.effect.SoundEffect;
 import com.elmakers.mine.bukkit.magic.SpellParameters;
 import de.slikey.effectlib.util.ConfigUtils;
 import de.slikey.effectlib.util.ParticleEffect;
-
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -29,12 +29,11 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
-import com.elmakers.mine.bukkit.block.MaterialAndData;
-
 public class ConfigurationUtils extends ConfigUtils {
 
     public static Random random = new Random();
 
+    @Nullable
     public static Location getLocation(ConfigurationSection node, String path) {
         String stringData = node.getString(path);
         if (stringData == null) {
@@ -44,6 +43,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return toLocation(stringData);
     }
 
+    @Nullable
     public static BlockFace toBlockFace(String s) {
         BlockFace face = null;
         try {
@@ -63,10 +63,12 @@ public class ConfigurationUtils extends ConfigUtils {
         return vector.getX() + "," + vector.getY() + "," + vector.getZ();
     }
 
+    @Nullable
     public static Vector getVector(ConfigurationSection node, String path) {
        return getVector(node, path, null);
     }
 
+    @Nullable
     public static Vector getVector(ConfigurationSection node, String path, Vector def) {
         String stringData = node.getString(path, null);
         if (stringData == null) {
@@ -76,6 +78,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return toVector(stringData);
     }
 
+    @Nullable
     public static Material getMaterial(ConfigurationSection node, String path, Material def) {
         String stringData = node.getString(path);
         if (stringData == null) {
@@ -85,10 +88,12 @@ public class ConfigurationUtils extends ConfigUtils {
         return toMaterial(stringData);
     }
 
+    @Nullable
     public static MaterialAndData getMaterialAndData(ConfigurationSection node, String path) {
         return getMaterialAndData(node, path, null);
     }
 
+    @Nullable
     public static MaterialAndData getMaterialAndData(ConfigurationSection node, String path, MaterialAndData def) {
         String stringData = node.getString(path);
         if (stringData == null) {
@@ -98,6 +103,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return toMaterialAndData(stringData);
     }
 
+    @Nullable
     public static Material getMaterial(ConfigurationSection node, String path) {
         return getMaterial(node, path, null);
     }
@@ -120,6 +126,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return fromLocation(block.getLocation()) + "|" + block.getTypeId() + ":" + block.getData();
     }
 
+    @Nullable
     public static Location toLocation(Object o) {
         if (o instanceof Location) {
             return (Location)o;
@@ -150,6 +157,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return null;
     }
 
+    @Nullable
     public static Vector toVector(Object o) {
         if (o instanceof Vector) {
             return (Vector)o;
@@ -174,6 +182,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return null;
     }
 
+    @Nullable
     @SuppressWarnings("deprecation")
     public static Material toMaterial(Object o)
     {
@@ -200,7 +209,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return null;
     }
 
-    public static MaterialAndData toMaterialAndData(Object o)
+    @Nullable public static MaterialAndData toMaterialAndData(Object o)
     {
         if (o instanceof MaterialAndData) {
             return (MaterialAndData)o;
@@ -297,7 +306,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return replaced;
     }
 
-    private static Object replaceParameters(Object value, ConfigurationSection parameters)
+    @Nullable private static Object replaceParameters(Object value, ConfigurationSection parameters)
     {
         if (value == null) return null;
         if (value instanceof Map)
@@ -346,7 +355,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return parameters.get(value.substring(1));
     }
 
-    public static ConfigurationSection replaceParameters(ConfigurationSection configuration, ConfigurationSection parameters)
+    @Nullable public static ConfigurationSection replaceParameters(ConfigurationSection configuration, ConfigurationSection parameters)
     {
         if (configuration == null) return null;
         
@@ -506,10 +515,12 @@ public class ConfigurationUtils extends ConfigUtils {
         return overrideDouble(override, value);
     }
 
+    @Nullable
     public static World overrideWorld(ConfigurationSection node, String path, World world, boolean canCreateWorlds) {
         return overrideWorld(node.getString(path), world, canCreateWorlds);
     }
 
+    @Nullable
     public static World overrideWorld(String worldName, World world, boolean canCreateWorlds) {
         if (worldName == null || worldName.length() == 0) return null;
 
@@ -546,7 +557,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return worldOverride;
     }
 
-    public static Location overrideLocation(ConfigurationSection node, String basePath, Location location, boolean canCreateWorlds)
+    @Nullable public static Location overrideLocation(ConfigurationSection node, String basePath, Location location, boolean canCreateWorlds)
     {
         String xName = basePath + "x";
         String yName = basePath + "y";
@@ -594,7 +605,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return o == null ? def : o;
     }
 
-    public static Color toColor(Object o) {
+    @Nullable public static Color toColor(Object o) {
         if (o == null) {
             return null;
         } else if (o instanceof Byte) {
@@ -646,7 +657,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return def;
     }
 
-    @SuppressWarnings("unchecked")
+    @Nullable @SuppressWarnings("unchecked")
     public static List<Object> getList(ConfigurationSection section, String path) {
         Object o = section.get(path);
         if (o == null) {
@@ -673,7 +684,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return list == null ? (def == null ? new ArrayList<String>() : def) : list;
     }
 
-    public static List<String> getStringList(ConfigurationSection section, String path) {
+    @Nullable public static List<String> getStringList(ConfigurationSection section, String path) {
         List<Object> raw = getList(section, path);
 
         if (raw == null) {
@@ -727,7 +738,7 @@ public class ConfigurationUtils extends ConfigUtils {
       * @param o the object to cast
       * @return an Integer, or null on failure
       */
-     private static Integer castInt(Object o) {
+     @Nullable private static Integer castInt(Object o) {
          if (o == null) {
              return null;
          } else if (o instanceof Byte) {
@@ -779,7 +790,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return new SoundEffect(soundConfig);
     }
 
-    public static ParticleEffect toParticleEffect(String effectParticleName) {
+    @Nullable public static ParticleEffect toParticleEffect(String effectParticleName) {
         ParticleEffect effectParticle = null;
         if (effectParticleName.length() > 0) {
             String particleName = effectParticleName.toUpperCase();
@@ -852,18 +863,18 @@ public class ConfigurationUtils extends ConfigUtils {
         return requiredSpells;
     }
 
-    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig)
-    {
+    @Nullable
+    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig) {
         return getPotionEffects(effectConfig, null);
     }
 
-    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig, Integer duration)
-    {
+    @Nullable
+    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig, Integer duration) {
         return getPotionEffects(effectConfig, duration, true, true);
     }
 
-    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig, Integer duration, boolean ambient, boolean particles)
-    {
+    @Nullable
+    public static Collection<PotionEffect> getPotionEffects(ConfigurationSection effectConfig, Integer duration, boolean ambient, boolean particles) {
         if (effectConfig == null) return null;
         List<PotionEffect> effects = new ArrayList<>();
         Set<String> keys = effectConfig.getKeys(false);
@@ -897,7 +908,7 @@ public class ConfigurationUtils extends ConfigUtils {
         return effects;
     }
 
-    public static List<PotionEffect> getPotionEffectObjects(ConfigurationSection baseConfig, String key, Logger log) {
+    @Nullable public static List<PotionEffect> getPotionEffectObjects(ConfigurationSection baseConfig, String key, Logger log) {
         List<PotionEffect> potionEffects = null;
         Collection<ConfigurationSection> potionEffectList = getNodeList(baseConfig, key);
         if (potionEffectList != null) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/HitboxUtils.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/HitboxUtils.java
@@ -1,5 +1,10 @@
 package com.elmakers.mine.bukkit.utility;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
@@ -8,11 +13,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Level;
 
 public class HitboxUtils extends CompatibilityUtils {
     private final static Map<EntityType, BoundingBox> hitboxes = new HashMap<>();
@@ -32,7 +32,7 @@ public class HitboxUtils extends CompatibilityUtils {
         return new BoundingBox(blockX + 0.001, blockX + 0.999, blockY + 0.001, blockY + 0.999, blockZ + 0.001, blockZ + 0.999);
     }
 
-    public static BoundingBox getHitbox(Entity entity)
+    @Nullable public static BoundingBox getHitbox(Entity entity)
     {
         if (entity == null)
         {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/Messages.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/Messages.java
@@ -1,5 +1,7 @@
 package com.elmakers.mine.bukkit.utility;
 
+import com.elmakers.mine.bukkit.block.MaterialAndData;
+import com.elmakers.mine.bukkit.integration.VaultController;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -9,9 +11,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.elmakers.mine.bukkit.block.MaterialAndData;
-import com.elmakers.mine.bukkit.integration.VaultController;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
@@ -91,6 +91,7 @@ public class Messages implements com.elmakers.mine.bukkit.api.magic.Messages {
         return get(key, key).replace(paramName1, paramValue1).replace(paramName2, paramValue2);
     }
 
+    @Nullable
     @Override
     public String getRandomized(String key) {
         if (!randomized.containsKey(key)) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/RandomUtils.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/RandomUtils.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
@@ -32,7 +32,7 @@ public class RandomUtils {
         return (T)(Number)((Float)previousValue + distance * ((Float)nextValue - (Float)previousValue));
     }
 
-    public static <T extends Object> T weightedRandom(LinkedList<WeightedPair<T>> weightList) {
+    @Nullable public static <T extends Object> T weightedRandom(LinkedList<WeightedPair<T>> weightList) {
         if (weightList == null || weightList.size() == 0) return null;
 
         Float maxWeight = weightList.getLast().getThreshold();
@@ -154,7 +154,7 @@ public class RandomUtils {
         return base;
     }
 
-    public static String getEntry(String csvList, int index)
+    @Nullable public static String getEntry(String csvList, int index)
     {
         if (csvList == null) return null;
         String[] pieces = StringUtils.split(csvList, ',');

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/utility/Target.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/utility/Target.java
@@ -2,6 +2,8 @@ package com.elmakers.mine.bukkit.utility;
 
 import java.lang.ref.WeakReference;
 
+import javax.annotation.Nullable;
+
 import com.elmakers.mine.bukkit.block.MaterialAndData;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -424,13 +426,13 @@ public class Target implements Comparable<Target>
         return location != null;
     }
 
-    public Entity getEntity()
-    {
+    @Nullable
+    public Entity getEntity() {
         return _entity == null ? null : _entity.get();
     }
 
-    public Block getBlock()
-    {
+    @Nullable
+    public Block getBlock() {
         if (location == null)
         {
             return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/wand/Wand.java
@@ -98,8 +98,10 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
      * used for off-hand casting.
      */
     protected @Nullable Mage mage;
-    protected @Nullable CastContext effectsContext;
-	
+
+    // Lazy loaded
+    protected CastContext effectsContext;
+
 	// Cached state
 	private String id = "";
 	private List<Inventory> hotbars;
@@ -805,6 +807,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return template != null && template.hasTag(tag);
 	}
 
+    @Nullable
     @Override
     public WandUpgradePath getPath() {
         String pathKey = path;
@@ -874,7 +877,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		saveState();
 	}
 
-	public String getControlKey(WandAction action) {
+	@Nullable public String getControlKey(WandAction action) {
     	String controlKey = null;
 		if (rightClickAction == action) {
 			controlKey = "right_click";
@@ -888,8 +891,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 
 		return controlKey;
 	}
-	
-	@Override
+
+    @Nullable
+    @Override
     public ItemStack getItem() {
 		return item;
 	}
@@ -937,7 +941,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return brushes;
 	}
 
-	protected Integer parseSlot(String[] pieces) {
+	@Nullable protected Integer parseSlot(String[] pieces) {
 		Integer slot = null;
 		if (pieces.length > 1) {
 			try {
@@ -1209,22 +1213,26 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		}
 	}
 
+    @Nullable
     protected ItemStack createSpellIcon(SpellTemplate spell) {
         return createSpellItem(spell, "", controller, getActiveMage(), this, false);
     }
 
+    @Nullable
     public static ItemStack createSpellItem(String spellKey, MagicController controller, Wand wand, boolean isItem) {
         String[] split = spellKey.split(" ", 2);
         return createSpellItem(controller.getSpellTemplate(split[0]), split.length > 1 ? split[1] : "", controller, wand == null ? null : wand.getActiveMage(), wand, isItem);
     }
 
+    @Nullable
     public static ItemStack createSpellItem(String spellKey, MagicController controller, com.elmakers.mine.bukkit.api.magic.Mage mage, Wand wand, boolean isItem) {
         String[] split = spellKey.split(" ", 2);
         return createSpellItem(controller.getSpellTemplate(split[0]), split.length > 1 ? split[1] : "", controller, mage, wand, isItem);
     }
 
-	public static ItemStack createSpellItem(SpellTemplate spell, String args, MagicController controller, com.elmakers.mine.bukkit.api.magic.Mage mage, Wand wand, boolean isItem) {
-		if (spell == null) return null;
+    @Nullable
+    public static ItemStack createSpellItem(SpellTemplate spell, String args, MagicController controller, com.elmakers.mine.bukkit.api.magic.Mage mage, Wand wand, boolean isItem) {
+        if (spell == null) return null;
         String iconURL = spell.getIconURL();
 
         ItemStack itemStack = null;
@@ -1279,12 +1287,14 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 
 		return itemStack;
 	}
-	
-	protected ItemStack createBrushIcon(String materialKey) {
-		return createBrushItem(materialKey, controller, this, false);
-	}
-	
-	public static ItemStack createBrushItem(String materialKey, com.elmakers.mine.bukkit.api.magic.MageController controller, Wand wand, boolean isItem) {
+
+    @Nullable
+    protected ItemStack createBrushIcon(String materialKey) {
+        return createBrushItem(materialKey, controller, this, false);
+    }
+
+    @Nullable
+    public static ItemStack createBrushItem(String materialKey, com.elmakers.mine.bukkit.api.magic.MageController controller, Wand wand, boolean isItem) {
 		MaterialBrush brushData = MaterialBrush.parseMaterialKey(materialKey);
 		if (brushData == null) return null;
 
@@ -1353,7 +1363,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         }
 	}
 
-    public static ConfigurationSection itemToConfig(ItemStack item, ConfigurationSection stateNode) {
+    @Nullable public static ConfigurationSection itemToConfig(ItemStack item, ConfigurationSection stateNode) {
         Object wandNode = InventoryUtils.getNode(item, WAND_KEY);
 
         if (wandNode == null) {
@@ -1376,7 +1386,8 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         }
     }
 
-    protected String getPotionEffectString() {
+    @Nullable
+    private String getPotionEffectString() {
         return getPotionEffectString(potionEffects);
     }
 
@@ -2313,7 +2324,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		}
 	}
 
-	protected String getPathName() {
+	@Nullable protected String getPathName() {
     	String pathName = null;
 		com.elmakers.mine.bukkit.api.wand.WandUpgradePath path = getPath();
 		if (path != null) {
@@ -2489,7 +2500,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return isWand(activeItem);
 	}
 	
-	public static Wand getActiveWand(MagicController controller, Player player) {
+	@Nullable public static Wand getActiveWand(MagicController controller, Player player) {
 		ItemStack activeItem =  player.getInventory().getItemInMainHand();
 		if (isWand(activeItem)) {
 			return controller.getWand(activeItem);
@@ -2526,7 +2537,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return InventoryUtils.hasMeta(item, "sp");
 	}
 
-	public static Integer getSP(ItemStack item) {
+	@Nullable public static Integer getSP(ItemStack item) {
 		if (InventoryUtils.isEmpty(item)) return null;
 		String spNode = InventoryUtils.getMetaString(item, "sp");
 		if (spNode == null) return null;
@@ -2556,7 +2567,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return item != null && InventoryUtils.hasMeta(item, "brush");
 	}
 
-	protected static Object getWandOrUpgradeNode(ItemStack item) {
+	@Nullable protected static Object getWandOrUpgradeNode(ItemStack item) {
 		if (InventoryUtils.isEmpty(item)) return null;
 		Object wandNode = InventoryUtils.getNode(item, WAND_KEY);
 		if (wandNode == null) {
@@ -2565,27 +2576,28 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return wandNode;
 	}
 
-    public static String getWandTemplate(ItemStack item) {
+    @Nullable public static String getWandTemplate(ItemStack item) {
         Object wandNode = getWandOrUpgradeNode(item);
         if (wandNode == null) return null;
         return InventoryUtils.getMetaString(wandNode, "template");
     }
 
-    public static String getWandId(ItemStack item) {
+    @Nullable public static String getWandId(ItemStack item) {
 		if (InventoryUtils.isEmpty(item)) return null;
         Object wandNode = InventoryUtils.getNode(item, WAND_KEY);
         if (wandNode == null) return null;
         return InventoryUtils.getMetaString(wandNode, "id");
     }
 
-	public static String getSpell(ItemStack item) {
-		if (InventoryUtils.isEmpty(item)) return null;
+    @Nullable
+    public static String getSpell(ItemStack item) {
+        if (InventoryUtils.isEmpty(item)) return null;
         Object spellNode = InventoryUtils.getNode(item, "spell");
         if (spellNode == null) return null;
         return InventoryUtils.getMetaString(spellNode, "key");
 	}
 
-    public static String getSpellClass(ItemStack item) {
+    @Nullable public static String getSpellClass(ItemStack item) {
         if (InventoryUtils.isEmpty(item)) return null;
         Object spellNode = InventoryUtils.getNode(item, "spell");
         if (spellNode == null) return null;
@@ -2600,15 +2612,17 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return quickCast == null ? true : quickCast;
     }
 
+    @Nullable
     public static String getSpellArgs(ItemStack item) {
-		if (InventoryUtils.isEmpty(item)) return null;
+        if (InventoryUtils.isEmpty(item)) return null;
         Object spellNode = InventoryUtils.getNode(item, "spell");
         if (spellNode == null) return null;
         return InventoryUtils.getMetaString(spellNode, "args");
     }
 
+    @Nullable
     public static String getBrush(ItemStack item) {
-		if (InventoryUtils.isEmpty(item)) return null;
+        if (InventoryUtils.isEmpty(item)) return null;
         Object brushNode = InventoryUtils.getNode(item, "brush");
         if (brushNode == null) return null;
         return InventoryUtils.getMetaString(brushNode, "key");
@@ -3018,7 +3032,8 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return levels;
 	}
 
-    public static ItemStack createItem(MagicController controller, String templateName) {
+    @Nullable
+    private static ItemStack createItem(MagicController controller, String templateName) {
         ItemStack item = createSpellItem(templateName, controller, null, true);
         if (item == null) {
             item = createBrushItem(templateName, controller, null, true);
@@ -3032,8 +3047,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 
         return item;
     }
-	
-	public static Wand createWand(MagicController controller, String templateName) {
+
+    @Nullable
+    public static Wand createWand(MagicController controller, String templateName) {
 		if (controller == null) return null;
 		
 		Wand wand = null;
@@ -3047,6 +3063,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return wand; 
 	}
 
+    @Nullable
     public static Wand createWand(MagicController controller, ItemStack itemStack) {
         if (controller == null) return null;
 
@@ -3748,8 +3765,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		this.mage = null;
 		updateMaxMana(true);
 	}
-	
-	@Override
+
+    @Nullable
+    @Override
     public Spell getActiveSpell() {
 		if (mage == null) return null;
 		String activeSpellKey = getActiveSpellKey();
@@ -3757,22 +3775,23 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return mage.getSpell(activeSpellKey);
 	}
 
-	public Spell getAlternateSpell() {
+	@Nullable public Spell getAlternateSpell() {
 		if (mage == null || alternateSpell == null || alternateSpell.length() == 0) return null;
 		return mage.getSpell(alternateSpell);
 	}
 
-	public Spell getAlternateSpell2() {
+	@Nullable public Spell getAlternateSpell2() {
 		if (mage == null || alternateSpell2 == null || alternateSpell2.length() == 0) return null;
 		return mage.getSpell(alternateSpell2);
 	}
 
+    @Nullable
     @Override
     public SpellTemplate getBaseSpell(String spellName) {
         return getBaseSpell(new SpellKey(spellName));
     }
 
-    public SpellTemplate getBaseSpell(SpellKey key) {
+    @Nullable public SpellTemplate getBaseSpell(SpellKey key) {
     	if (!spells.contains(key.getBaseKey())) return null;
         SpellKey baseKey = new SpellKey(key.getBaseKey(), getSpellLevel(key.getBaseKey()));
         return controller.getSpellTemplate(baseKey.getKey());
@@ -4038,7 +4057,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		setActiveBrush(StringUtils.split(materials.get(materialIndex), '@')[0]);
 	}
 
-	public Mage getActiveMage() {
+	@Nullable public Mage getActiveMage() {
 		return mage;
 	}
 
@@ -4049,8 +4068,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		}
 	}
 
-	@Override
-	public Color getEffectColor() {
+    @Nullable
+    @Override
+    public Color getEffectColor() {
 		return effectColor == null ? null : effectColor.getColor();
 	}
 
@@ -4058,12 +4078,14 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return effectParticle;
     }
 
-	@Override
-	public String getEffectParticleName() {
+    @Nullable
+    @Override
+    public String getEffectParticleName() {
 		return effectParticle == null ? null : effectParticle.name();
 	}
 
-	public Inventory getHotbar() {
+    @Nullable
+    public Inventory getHotbar() {
         if (this.hotbars.size() == 0) return null;
 
 		if (currentHotbar < 0 || currentHotbar >= this.hotbars.size())
@@ -5080,9 +5102,10 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
     public boolean isBound() {
         return bound;
     }
-	
-	@Override
-	public Spell getSpell(String spellKey, com.elmakers.mine.bukkit.api.magic.Mage mage) {
+
+    @Nullable
+    @Override
+    public Spell getSpell(String spellKey, com.elmakers.mine.bukkit.api.magic.Mage mage) {
 		if (mage == null) {
 			return null;
 		}
@@ -5095,9 +5118,10 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		}
 		return mage.getSpell(spellKey);
 	}
-	
-	@Override
-	public SpellTemplate getSpellTemplate(String spellKey) {
+
+    @Nullable
+    @Override
+    public SpellTemplate getSpellTemplate(String spellKey) {
 		SpellKey key = new SpellKey(spellKey);
 		spellKey = key.getBaseKey();
 		if (!spells.contains(spellKey)) return null;
@@ -5107,10 +5131,11 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		}
 		return controller.getSpellTemplate(spellKey);
 	}
-	
-	@Override
+
+    @Nullable
+    @Override
     public Spell getSpell(String spellKey) {
-		return getSpell(spellKey, mage);
+        return getSpell(spellKey, mage);
     }
 
 	private void setSpellLevel(String spellKey, int level) {
@@ -5176,8 +5201,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return level != null && level > 0 ? (float)level : 0;
     }
 
-	@Override
-	public WandTemplate getTemplate() {
+    @Nullable
+    @Override
+    public WandTemplate getTemplate() {
 		if (template == null || template.isEmpty()) return null;
 		return controller.getWandTemplate(template);
 	}
@@ -5346,8 +5372,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return isReflected;
 	}
 
-	@Override
-	public Location getLocation() {
+    @Nullable
+    @Override
+    public Location getLocation() {
 		if (mage == null) {
 			return null;
 		}
@@ -5356,8 +5383,9 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
 		return wandLocation;
 	}
 
-	@Override
-	public Mage getMage() {
+    @Nullable
+    @Override
+    public Mage getMage() {
 		return mage;
 	}
 
@@ -5397,6 +5425,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return heldSlot;
     }
 
+    @Nullable
     @Override
     protected BaseMagicConfigurable getStorage(MagicPropertyType propertyType) {
         switch (propertyType) {
@@ -5427,6 +5456,7 @@ public class Wand extends WandProperties implements CostReducer, com.elmakers.mi
         return mage == null ? false : mage.isPlayer();
     }
 
+    @Nullable
     @Override
     public Player getPlayer() {
         return mage == null ? null : mage.getPlayer();

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/wand/WandTemplate.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/wand/WandTemplate.java
@@ -8,20 +8,18 @@ import com.elmakers.mine.bukkit.magic.BaseMagicProperties;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-
-import org.bukkit.Location;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
 
 public class WandTemplate extends BaseMagicProperties implements com.elmakers.mine.bukkit.api.wand.WandTemplate {
     private final String key;
@@ -220,6 +218,7 @@ public class WandTemplate extends BaseMagicProperties implements com.elmakers.mi
         return categories;
     }
 
+    @Nullable
     @Override
     public WandTemplate getMigrateTemplate() {
         return migrateTemplate == null ? null : controller.getWandTemplate(migrateTemplate);
@@ -260,6 +259,7 @@ public class WandTemplate extends BaseMagicProperties implements com.elmakers.mi
         return attributeSlot;
     }
 
+    @Nullable
     @Override
     public com.elmakers.mine.bukkit.api.wand.WandTemplate getParent() {
         if (parentKey != null && !parentKey.isEmpty() && !parentKey.equalsIgnoreCase("false")) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/wand/WandUpgradePath.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/wand/WandUpgradePath.java
@@ -3,26 +3,16 @@ package com.elmakers.mine.bukkit.wand;
 import com.elmakers.mine.bukkit.api.event.PathUpgradeEvent;
 import com.elmakers.mine.bukkit.api.event.WandUpgradeEvent;
 import com.elmakers.mine.bukkit.api.magic.CasterProperties;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.magic.Messages;
 import com.elmakers.mine.bukkit.api.spell.PrerequisiteSpell;
 import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
 import com.elmakers.mine.bukkit.block.MaterialAndData;
 import com.elmakers.mine.bukkit.effect.EffectPlayer;
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.WeightedPair;
-import org.apache.commons.lang.StringUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.MemoryConfiguration;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +23,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 
 /**
  * A represents a randomized upgrade path that a wand may use
@@ -280,7 +280,7 @@ public class WandUpgradePath implements com.elmakers.mine.bukkit.api.wand.WandUp
         return key;
     }
 
-    public WandLevel getLevel(int level) {
+    @Nullable public WandLevel getLevel(int level) {
         if (levelMap == null) return null;
 
         if (!levelMap.containsKey(level)) {
@@ -294,8 +294,8 @@ public class WandUpgradePath implements com.elmakers.mine.bukkit.api.wand.WandUp
         return levelMap.get(level);
     }
 
-    protected static WandUpgradePath getPath(MageController controller, String key, ConfigurationSection configuration)
-    {
+    @Nullable
+    protected static WandUpgradePath getPath(MageController controller, String key, ConfigurationSection configuration) {
         WandUpgradePath path = paths.get(key);
         if (path == null) {
             ConfigurationSection parameters = configuration.getConfigurationSection(key);
@@ -334,6 +334,7 @@ public class WandUpgradePath implements com.elmakers.mine.bukkit.api.wand.WandUp
         return paths.keySet();
     }
 
+    @Nullable
     public static WandUpgradePath getPath(String key) {
         return paths.get(key);
     }
@@ -344,6 +345,7 @@ public class WandUpgradePath implements com.elmakers.mine.bukkit.api.wand.WandUp
         return Math.min(levels[levels.length - 1], maxLevel);
     }
 
+    @Nullable
     public Set<Integer> getLevels() {
         if (levelMap == null) return null;
         Set<Integer> filteredLevels = new HashSet<>();
@@ -540,6 +542,7 @@ public class WandUpgradePath implements com.elmakers.mine.bukkit.api.wand.WandUp
         return upgradeKey != null && !upgradeKey.isEmpty();
     }
 
+    @Nullable
     @Override
     public WandUpgradePath getUpgrade() {
         return getPath(upgradeKey);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/warp/CommandBookWarps.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/warp/CommandBookWarps.java
@@ -6,6 +6,7 @@ import com.sk89q.commandbook.locations.RootLocationManager;
 import com.sk89q.commandbook.locations.WarpsComponent;
 import com.zachsthings.libcomponents.ComponentManager;
 import com.zachsthings.libcomponents.bukkit.BukkitComponent;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
 
@@ -20,7 +21,7 @@ public class CommandBookWarps {
         this.locationManager = locationManager;
     }
 
-    public static CommandBookWarps create(Plugin plugin)
+    @Nullable public static CommandBookWarps create(Plugin plugin)
     {
         if (plugin instanceof CommandBook) {
             ComponentManager<BukkitComponent> componentManager = ((CommandBook)plugin).getComponentManager();
@@ -34,7 +35,7 @@ public class CommandBookWarps {
         return null;
     }
 
-    public Location getWarp(String warpName) {
+    @Nullable public Location getWarp(String warpName) {
         if (locationManager == null) return null;
         NamedLocation location = locationManager.get(null, warpName);
         if (location == null) return null;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/warp/EssentialsWarps.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/warp/EssentialsWarps.java
@@ -2,6 +2,7 @@ package com.elmakers.mine.bukkit.warp;
 
 import com.earth2me.essentials.Essentials;
 import com.earth2me.essentials.Warps;
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
 
@@ -15,7 +16,7 @@ public class EssentialsWarps {
         this.warps = warps;
     }
 
-    public static EssentialsWarps create(Plugin plugin) {
+    @Nullable public static EssentialsWarps create(Plugin plugin) {
         if (plugin instanceof Essentials) {
             Essentials essentials = (Essentials)plugin;
             Warps warps = essentials.getWarps();
@@ -25,7 +26,7 @@ public class EssentialsWarps {
         return null;
     }
 
-    public Location getWarp(String warpName) {
+    @Nullable public Location getWarp(String warpName) {
         try {
             return warps.getWarp(warpName);
         } catch (Exception ex) {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/warp/WarpController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/warp/WarpController.java
@@ -1,5 +1,6 @@
 package com.elmakers.mine.bukkit.warp;
 
+import javax.annotation.Nullable;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
 
@@ -7,7 +8,7 @@ public class WarpController {
     private CommandBookWarps commandBook;
     private EssentialsWarps essentials;
 	
-	public Location getWarp(String warpName) {
+	@Nullable public Location getWarp(String warpName) {
         Location warp = null;
         if (commandBook != null) {
             warp = commandBook.getWarp(warpName);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/action/CastContext.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/action/CastContext.java
@@ -33,17 +33,24 @@ import com.elmakers.mine.bukkit.api.spell.TargetType;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 
 public interface CastContext {
+    @Nullable
     Entity getEntity();
     LivingEntity getLivingEntity();
+    @Nullable
     Location getLocation();
+    @Nullable
     Location getTargetLocation();
+    @Nullable
     Location getTargetCenterLocation();
     void setTargetCenterLocation(Location location);
+    @Nullable
     Location getTargetSourceLocation();
     Vector getDirection();
     BlockFace getFacingDirection();
     void setDirection(Vector direction);
+    @Nullable
     World getWorld();
+    @Nullable
     Plugin getPlugin();
     Location getEyeLocation();
 
@@ -53,15 +60,20 @@ public interface CastContext {
      * a wand.
      * @return
      */
+    @Nullable
     Location getWandLocation();
 
     /**
      * Get the source location of this cast.
      * @return
      */
+    @Nullable
     Location getCastLocation();
+    @Nullable
     Block getTargetBlock();
+    @Nullable
     Block getInteractBlock();
+    @Nullable
     Entity getTargetEntity();
     void setTargetEntity(Entity targetEntity);
     void setTargetLocation(Location targetLocation);
@@ -69,9 +81,11 @@ public interface CastContext {
     Spell getSpell();
     Mage getMage();
     Wand getWand();
-    @Nullable MageClass getMageClass();
+    @Nullable
+    MageClass getMageClass();
     Collection<EffectPlayer> getEffects(String key);
     boolean hasEffects(String key);
+    @Nullable
     MageController getController();
     void registerForUndo(Runnable runnable);
     void registerModified(Entity entity);
@@ -93,7 +107,9 @@ public interface CastContext {
     boolean hasBreakPermission(Block block);
     boolean isBreakable(Block block);
     boolean isReflective(Block block);
+    @Nullable
     Double getBreakable(Block block);
+    @Nullable
     Double getReflective(Block block);
     void clearBreakable(Block block);
     void clearReflective(Block block);
@@ -105,7 +121,9 @@ public interface CastContext {
     void cancelEffects();
     String getMessage(String key);
     String getMessage(String key, String def);
+    @Nullable
     Location findPlaceToStand(Location target, int verticalSearchDistance);
+    @Nullable
     Location findPlaceToStand(Location target, int verticalSearchDistance, boolean goUp);
     void castMessage(String message);
     void sendMessage(String message);
@@ -127,6 +145,7 @@ public interface CastContext {
     boolean isTargetable(Block block);
     boolean canTarget(Entity entity);
     boolean canTarget(Entity entity, Class<?> targetType);
+    @Nullable
     MaterialBrush getBrush();
     void setBrush(MaterialBrush brush);
     Collection<Entity> getTargetedEntities();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/attributes/AttributeProvider.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/attributes/AttributeProvider.java
@@ -1,10 +1,14 @@
 package com.elmakers.mine.bukkit.api.attributes;
 
-import org.bukkit.entity.Player;
-
 import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.entity.Player;
 
 public interface AttributeProvider {
     Set<String> getAllAttributes();
+
+    @Nullable
     Double getAttributeValue(String attribute, Player player);
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/BlockData.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/BlockData.java
@@ -2,6 +2,8 @@ package com.elmakers.mine.bukkit.api.block;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -21,8 +23,10 @@ import com.elmakers.mine.bukkit.api.magic.MaterialSet;
  */
 public interface BlockData extends MaterialAndData {
     long getId();
+    @Nullable
     World getWorld();
     String getWorldName();
+    @Nullable
     Block getBlock();
     BlockVector getPosition();
     void restore();
@@ -38,6 +42,7 @@ public interface BlockData extends MaterialAndData {
     void setNextState(BlockData next);
     BlockData getPriorState();
     void setPriorState(BlockData prior);
+    @Nullable
     UndoList getUndoList();
     void setUndoList(UndoList undoList);
     BlockVector getLocation();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/BlockList.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/BlockList.java
@@ -2,6 +2,8 @@ package com.elmakers.mine.bukkit.api.block;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.util.Vector;
@@ -17,6 +19,7 @@ import org.bukkit.util.Vector;
 public interface BlockList extends Collection<BlockData> {
     void save(ConfigurationSection node);
     void load(ConfigurationSection node);
+    @Nullable
     String getWorldName();
     BoundingBox getArea();
     boolean add(Block block);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/MaterialAndData.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/MaterialAndData.java
@@ -1,10 +1,13 @@
 package com.elmakers.mine.bukkit.api.block;
 
-import com.elmakers.mine.bukkit.api.magic.Messages;
+import javax.annotation.Nullable;
+
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
+
+import com.elmakers.mine.bukkit.api.magic.Messages;
 
 /**
  * A utility interface for presenting a Material in its entirety, including Material variants.
@@ -47,22 +50,29 @@ public interface MaterialAndData {
     void modify(Block block);
     void modify(Block block, boolean applyPhysics);
     void modify(Block block, ModifyType modifyType);
+    @Nullable
     Short getData();
+    @Nullable
     Byte getBlockData();
     void setData(Short data);
+    @Nullable
     Material getMaterial();
     String getKey();
     String getName();
     String getName(Messages messages);
+    @Nullable
     String getBaseName();
     boolean is(Block block);
     boolean isDifferent(Block block);
+    @Nullable
     ItemStack getItemStack(int amount);
     boolean isValid();
+    @Nullable
     String getCommandLine();
     void setCommandLine(String commandLine);
     void setCustomName(String customName);
     void setRawData(Object data);
     ItemStack applyToItem(ItemStack stack);
+    @Nullable
     MaterialData getMaterialData();
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/MaterialBrush.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/MaterialBrush.java
@@ -2,17 +2,20 @@ package com.elmakers.mine.bukkit.api.block;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
 
 import com.elmakers.mine.bukkit.api.entity.EntityData;
 import com.elmakers.mine.bukkit.api.magic.Mage;
-import org.bukkit.util.Vector;
 
 public interface MaterialBrush extends MaterialAndData {
     void prepare();
     boolean isReady();
     Collection<EntityData> getEntities();
+    @Nullable
     Collection<Entity> getTargetEntities();
     boolean hasEntities();
     boolean update(final Mage mage, final Location location);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/Schematic.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/Schematic.java
@@ -2,6 +2,8 @@ package com.elmakers.mine.bukkit.api.block;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
@@ -9,6 +11,7 @@ import com.elmakers.mine.bukkit.api.entity.EntityData;
 
 public interface Schematic {
     boolean contains(Vector v);
+    @Nullable
     MaterialAndData getBlock(Vector v);
     Collection<EntityData> getEntities(Location center);
     Vector getSize();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/UndoList.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/UndoList.java
@@ -4,16 +4,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.batch.Batch;
-import com.elmakers.mine.bukkit.api.entity.EntityData;
-import com.elmakers.mine.bukkit.api.spell.Spell;
+import javax.annotation.Nullable;
+
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-
-import com.elmakers.mine.bukkit.api.magic.Mage;
 import org.bukkit.entity.EntityType;
+
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.batch.Batch;
+import com.elmakers.mine.bukkit.api.entity.EntityData;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.spell.Spell;
 
 public interface UndoList extends BlockList, Comparable<UndoList> {
     void commit();
@@ -21,6 +23,7 @@ public interface UndoList extends BlockList, Comparable<UndoList> {
     void undo(boolean blocking);
     void undoScheduled();
     void undoScheduled(boolean blocking);
+    @Nullable
     BlockData undoNext(boolean applyPhysics);
 
     void setEntityUndo(boolean undoEntityEffects);
@@ -49,7 +52,9 @@ public interface UndoList extends BlockList, Comparable<UndoList> {
 
     void add(Entity entity);
     void remove(Entity entity);
+    @Nullable
     EntityData damage(Entity entity);
+    @Nullable
     EntityData modify(Entity entity);
     void add(Runnable runnable);
     void move(Entity entity);
@@ -69,6 +74,7 @@ public interface UndoList extends BlockList, Comparable<UndoList> {
 
     String getName();
     Mage getOwner();
+    @Nullable
     CastContext getContext();
     void setBypass(boolean bypass);
     Collection<Entity> getAllEntities();
@@ -89,5 +95,6 @@ public interface UndoList extends BlockList, Comparable<UndoList> {
     boolean hasChanges();
     
     int getRunnableCount();
+    @Nullable
     Runnable undoNextRunnable();
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/UndoQueue.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/block/UndoQueue.java
@@ -1,13 +1,18 @@
 package com.elmakers.mine.bukkit.api.block;
 
-import com.elmakers.mine.bukkit.api.data.UndoData;
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
 import org.bukkit.block.Block;
 
-import java.util.Collection;
+import com.elmakers.mine.bukkit.api.data.UndoData;
 
 public interface UndoQueue {
     void add(UndoList blocks);
+    @Nullable
     UndoList getLast();
+    @Nullable
     UndoList getLast(Block target);
 
     /**
@@ -23,7 +28,9 @@ public interface UndoQueue {
      * @param timeout The maximum age of the change
      * @return The UndoList that was undone, or null if none.
      */
+    @Nullable
     UndoList undoRecent(int timeout);
+    @Nullable
     UndoList undoRecent(int timeout, String spellKey);
 
     /**
@@ -41,6 +48,7 @@ public interface UndoQueue {
      * @param timeout The maximum age of the change
      * @return The UndoList that was undone, or null if the Mage has no constructions for the given Block.
      */
+    @Nullable
     UndoList undoRecent(Block block, int timeout);
 
     /**

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/data/MageData.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/data/MageData.java
@@ -1,14 +1,17 @@
 package com.elmakers.mine.bukkit.api.data;
 
-import com.elmakers.mine.bukkit.api.wand.Wand;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import com.elmakers.mine.bukkit.api.wand.Wand;
 
 public class MageData {
     private String id;
@@ -237,6 +240,7 @@ public class MageData {
     }
 
     @Deprecated
+    @Nullable
     public Wand getSoulWand() {
         return null;
     }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/effect/EffectPlayer.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/effect/EffectPlayer.java
@@ -1,17 +1,19 @@
 package com.elmakers.mine.bukkit.api.effect;
 
-import com.elmakers.mine.bukkit.api.action.CastContext;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import org.bukkit.Color;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
-
-import com.elmakers.mine.bukkit.api.block.MaterialAndData;
 import org.bukkit.entity.Entity;
 
-import java.util.Collection;
-import java.util.Map;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.block.MaterialAndData;
 
 public interface EffectPlayer {
     void setEffectPlayList(Collection<EffectPlay> plays);
@@ -29,7 +31,9 @@ public interface EffectPlayer {
     void setMaterial(MaterialAndData material);
     void setMaterial(Block block);
     void setColor(Color color);
+    @Nullable
     Location getSourceLocation(CastContext context);
+    @Nullable
     Location getTargetLocation(CastContext context);
 
     boolean playsAtOrigin();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/entity/EntityData.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/entity/EntityData.java
@@ -1,6 +1,7 @@
 package com.elmakers.mine.bukkit.api.entity;
 
-import com.elmakers.mine.bukkit.api.magic.MageController;
+import javax.annotation.Nullable;
+
 import org.bukkit.Art;
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
@@ -8,6 +9,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.inventory.ItemStack;
+
+import com.elmakers.mine.bukkit.api.magic.MageController;
 
 public interface EntityData {
     String getKey();
@@ -19,13 +22,19 @@ public interface EntityData {
     ItemStack getItem();
     double getHealth();
     void setHasMoved(boolean hasMoved);
+    @Nullable
     Entity spawn();
+    @Nullable
     Entity spawn(Location location);
+    @Nullable
     Entity spawn(MageController controller, Location location);
+    @Nullable
     Entity spawn(MageController controller, Location location, CreatureSpawnEvent.SpawnReason reason);
+    @Nullable
     Entity undo();
     boolean modify(MageController controller, Entity entity);
     boolean modify(Entity entity);
+    @Nullable
     EntityData getRelativeTo(Location center);
     String describe();
     String getInteractSpell();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/item/ItemData.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/item/ItemData.java
@@ -2,6 +2,8 @@ package com.elmakers.mine.bukkit.api.item;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -10,11 +12,14 @@ import org.bukkit.material.MaterialData;
 public interface ItemData {
     String getKey();
     double getWorth();
+    @Nullable
     ItemStack getItemStack(int amount);
     String getCreator();
     String getCreatorId();
     Set<String> getCategories();
     Material getType();
+    @Nullable
     MaterialData getMaterialData();
+    @Nullable
     ItemMeta getItemMeta();
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/CasterProperties.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/CasterProperties.java
@@ -1,10 +1,12 @@
 package com.elmakers.mine.bukkit.api.magic;
 
-import com.elmakers.mine.bukkit.api.spell.Spell;
-import org.bukkit.inventory.ItemStack;
+import java.util.Collection;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
+
+import org.bukkit.inventory.ItemStack;
+
+import com.elmakers.mine.bukkit.api.spell.Spell;
 
 public interface CasterProperties extends MagicConfigurable {
     boolean hasSpell(String spellKey);
@@ -18,8 +20,10 @@ public interface CasterProperties extends MagicConfigurable {
     void setManaMax(int manaMax);
     int getManaRegeneration();
     void setManaRegeneration(int manaRegeneration);
+    @Nullable
     ProgressionPath getPath();
     boolean canProgress();
+    @Nullable
     Double getAttribute(String attributeKey);
     void setAttribute(String attributeKey, Double attributeValue);
     boolean addItem(ItemStack item);
@@ -32,5 +36,6 @@ public interface CasterProperties extends MagicConfigurable {
      * @param spellKey The spell key to request
      * @return the Spell, or null if not present here.
      */
-    @Nullable Spell getSpell(String spellKey);
+    @Nullable
+    Spell getSpell(String spellKey);
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/Mage.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/Mage.java
@@ -104,13 +104,13 @@ public interface Mage extends CostReducer, CooldownReducer {
      * @return Location the location of the Mage's eyes, used for targeting.
      */
     Location getEyeLocation();
-    Location getOffhandWandLocation();
 
     /**
      * Gets the source location of spells cast by this mage, which were
      * not cast with a wand.
      * @return
      */
+    @Nullable
     Location getCastLocation();
 
     /**
@@ -119,7 +119,11 @@ public interface Mage extends CostReducer, CooldownReducer {
      * return null if the Mage is not holding a Wand.
      * @return
      */
+    @Nullable
     Location getWandLocation();
+    @Nullable
+    Location getOffhandWandLocation();
+
 
     /**
      * Get the direction this Mage is facing.
@@ -146,6 +150,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * @return The player backed by this Mage, or null for Automaton Mages.
      */
+    @Nullable
     Player getPlayer();
 
     /**
@@ -166,6 +171,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * @return The LivingEntity represented by this Mage
      */
+    @Nullable
     LivingEntity getLivingEntity();
 
     /**
@@ -210,9 +216,13 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * @return The batch that was cancelled, or null if nothing was pending.
      */
+    @Nullable
     Batch cancelPending();
+    @Nullable
     Batch cancelPending(String spellKey);
+    @Nullable
     Batch cancelPending(boolean force);
+    @Nullable
     Batch cancelPending(String spellKey, boolean force);
 
     /**
@@ -224,6 +234,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * @return The UndoList that was undone, or null if none.
      */
+    @Nullable
     UndoList undo();
 
     /**
@@ -237,6 +248,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      * @param block The block to check for modifications.
      * @return The UndoList that was undone, or null if the Mage has no constructions for the given Block.
      */
+    @Nullable
     UndoList undo(Block block);
 
     /**
@@ -287,6 +299,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * @return The current active wand, after checking
      */
+    @Nullable
     Wand checkWand();
 
     /**
@@ -299,6 +312,7 @@ public interface Mage extends CostReducer, CooldownReducer {
      * @param key The key of the Spell to retrieve.
      * @return The Spell instance for this Mage, or null if the Mage does not have access to this Spell.
      */
+    @Nullable
     MageSpell getSpell(String key);
 
     /**
@@ -379,7 +393,9 @@ public interface Mage extends CostReducer, CooldownReducer {
      */
     float getDamageMultiplier();
 
+    @Nullable
     Color getEffectColor();
+    @Nullable
     String getEffectParticleName();
     float getPower();
     float getPowerMultiplier();
@@ -411,6 +427,7 @@ public interface Mage extends CostReducer, CooldownReducer {
     // Used for checking if a brush is restricted
     // TODO: Pass some kind of proper data class instead
     boolean isRestricted(Material material, @Nullable Short data);
+    @Nullable
     @Deprecated
     Set<Material> getRestrictedMaterials();
     MaterialSet getRestrictedMaterialSet();
@@ -426,6 +443,7 @@ public interface Mage extends CostReducer, CooldownReducer {
     boolean registerForUndo(UndoList blocks);
     boolean prepareForUndo(UndoList blocks);
 
+    @Nullable
     Inventory getInventory();
     int removeItem(ItemStack item);
     boolean hasItem(ItemStack item);
@@ -476,6 +494,7 @@ public interface Mage extends CostReducer, CooldownReducer {
     boolean isValid();
     boolean hasPending();
     boolean restoreWand();
+    @Nullable
     UndoList getLastUndoList();
     boolean isStealth();
     boolean isSneaking();
@@ -502,6 +521,7 @@ public interface Mage extends CostReducer, CooldownReducer {
     void addSkillPoints(int delta);
     void setSkillPoints(int sp);
     boolean isAtMaxSkillPoints();
+    @Nullable
     WandUpgradePath getBoundWandPath(String templateKey);
     boolean unbind(String template);
     void unbind(Wand wand);
@@ -592,11 +612,13 @@ public interface Mage extends CostReducer, CooldownReducer {
      *
      * This wand never appears as an in-game item.
      */
+    @Nullable
     @Deprecated
     Wand getSoulWand();
 
     boolean isAutomaton();
 
+    @Nullable
     Double getAttribute(String attributeKey);
 
     /**

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/MageController.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/MageController.java
@@ -1,5 +1,26 @@
 package com.elmakers.mine.bukkit.api.magic;
 
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.Vector;
+
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.block.BlockList;
 import com.elmakers.mine.bukkit.api.block.CurrencyItem;
@@ -16,25 +37,6 @@ import com.elmakers.mine.bukkit.api.wand.LostWand;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.api.wand.WandTemplate;
 import com.elmakers.mine.bukkit.api.wand.WandUpgradePath;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.util.Vector;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
 
 /**
  * The controller is used for more advanced plugin interaction, and is
@@ -77,13 +79,20 @@ public interface MageController {
      * @param wandKey The template key, or blank for a default wand.
      * @return A new Wand instance, with a useable ItemStack.
      */
+    @Nullable
     Wand createWand(String wandKey);
+    @Nullable
     ItemStack createItem(String magicItemKey);
+    @Nullable
     ItemStack createItem(String magicItemKey, boolean brief);
+    @Nullable
     ItemStack createGenericItem(String itemKey);
     Wand createUpgrade(String wandKey);
+    @Nullable
     ItemStack createSpellItem(String spellKey);
+    @Nullable
     ItemStack createSpellItem(String spellKey, boolean brief);
+    @Nullable
     ItemStack createBrushItem(String brushKey);
 
     /**
@@ -95,6 +104,7 @@ public interface MageController {
      */
     Wand getWand(ItemStack item);
     Wand getWand(ConfigurationSection config);
+    @Nullable
     WandTemplate getWandTemplate(String key);
     Collection<WandTemplate> getWandTemplates();
     void loadWandTemplate(String key, ConfigurationSection wandNode);
@@ -102,16 +112,20 @@ public interface MageController {
 
     String describeItem(ItemStack item);
     String getItemKey(ItemStack item);
+    @Nullable
     String getWandKey(ItemStack item);
     boolean takeItem(Player player, ItemStack item);
     boolean hasItem(Player player, ItemStack item);
 
+    @Nullable
     SpellCategory getCategory(String key);
     Collection<SpellCategory> getCategories();
     Collection<SpellTemplate> getSpellTemplates();
     Collection<SpellTemplate> getSpellTemplates(boolean showHidden);
+    @Nullable
     SpellTemplate getSpellTemplate(String key);
     Set<String> getWandPathKeys();
+    @Nullable
     WandUpgradePath getPath(String key);
 
     void updateBlock(Block block);
@@ -122,6 +136,7 @@ public interface MageController {
     boolean canCreateWorlds();
     int getMaxUndoPersistSize();
 
+    @Nullable
     Schematic loadSchematic(String name);
 
     /**
@@ -130,6 +145,7 @@ public interface MageController {
     MaterialSetManager getMaterialSetManager();
     @Deprecated
     Collection<String> getMaterialSets();
+    @Nullable
     @Deprecated
     Set<Material> getMaterialSet(String string);
 
@@ -148,8 +164,11 @@ public interface MageController {
 
     String getMessagePrefix();
 
+    @Nullable
     String getReflectiveMaterials(Mage mage, Location location);
+    @Nullable
     String getDestructibleMaterials(Mage mage, Location location);
+    @Nullable
     Set<String> getSpellOverrides(Mage mage, Location location);
 
     Set<Material> getDestructibleMaterials();
@@ -168,6 +187,7 @@ public interface MageController {
     @Nonnull Mage getMage(Player player);
     @Nonnull Mage getMage(Entity entity);
     @Nonnull Mage getMage(String id, String name);
+    @Nullable
     Mage getRegisteredMage(String mageId);
     Mage getRegisteredMage(Entity entity);
     Mage getAutomaton(String id, String name);
@@ -181,7 +201,9 @@ public interface MageController {
     boolean hasPermission(CommandSender sender, String pNode, boolean defaultValue);
     boolean hasPermission(CommandSender sender, String pNode);
     boolean hasCastPermission(CommandSender sender, SpellTemplate spell);
+    @Nullable
     Boolean getRegionCastPermission(Player player, SpellTemplate spell, Location location);
+    @Nullable
     Boolean getPersonalCastPermission(Player player, SpellTemplate spell, Location location);
     boolean isPVPAllowed(Player player, Location location);
     boolean isExitAllowed(Player player, Location location);
@@ -217,13 +239,18 @@ public interface MageController {
 
     boolean sendMail(CommandSender sender, String fromPlayer, String toPlayer, String message);
 
+    @Nullable
     Location getWarp(String warpName);
+    @Nullable
     Location getTownLocation(Player player);
+    @Nullable
     Map<String, Location> getHomeLocations(Player player);
 
     void giveItemToPlayer(Player player, ItemStack itemStack);
 
+    @Nullable
     UndoList undoAny(Block target);
+    @Nullable
     UndoList undoRecent(Block target, int timeout);
     void scheduleUndo(UndoList undoList);
     void cancelScheduledUndo(UndoList undoList);
@@ -235,6 +262,7 @@ public interface MageController {
     double getWorthBase();
     double getWorthXP();
     double getWorthSkillPoints();
+    @Nullable
     ItemStack getWorthItem();
     double getWorthItemAmount();
     CurrencyItem getCurrency();
@@ -339,6 +367,7 @@ public interface MageController {
      * @param key
      * @return
      */
+    @Nullable
     ItemStack deserialize(ConfigurationSection root, String key);
 
     /**
@@ -365,15 +394,22 @@ public interface MageController {
     void disableItemSpawn();
     void enableItemSpawn();
     void setForceSpawn(boolean force);
+    @Nullable
     String getSpell(ItemStack item);
+    @Nullable
     String getSpellArgs(ItemStack item);
     
     Set<String> getMobKeys();
+    @Nullable
     Entity spawnMob(String key, Location location);
+    @Nullable
     EntityData getMob(String key);
+    @Nullable
     EntityData getMobByName(String name);
     EntityData loadMob(ConfigurationSection configuration);
+    @Nullable
     String getBlockSkin(Material blockType);
+    @Nullable
     String getMobSkin(EntityType mobType);
     void checkResourcePack(CommandSender sender);
     boolean sendResourcePackToAllPlayers(CommandSender sender);
@@ -382,17 +418,22 @@ public interface MageController {
     boolean commitOnQuit();
     
     Set<String> getItemKeys();
+    @Nullable
     ItemData getItem(String key);
+    @Nullable
     ItemData getOrCreateItem(String key);
+    @Nullable
     ItemData getItem(ItemStack match);
     void unloadItemTemplate(String key);
     void loadItemTemplate(String key, ConfigurationSection itemNode);
+    @Nullable
     Double getWorth(ItemStack item);
     boolean disguise(Entity entity, ConfigurationSection configuration);
     void managePlayerData(boolean external, boolean backupInventories);
     String getDefaultWandTemplate();
     String getHeroesSkillPrefix();
 
+    @Nullable
     Object getWandProperty(ItemStack itemStack, String key);
     @Nonnull <T> T getWandProperty(ItemStack itemStack, @Nonnull String key, @Nonnull T defaultValue);
 

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/MagicAPI.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/MagicAPI.java
@@ -3,8 +3,8 @@ package com.elmakers.mine.bukkit.api.magic;
 import java.util.Collection;
 import java.util.logging.Logger;
 
-import com.elmakers.mine.bukkit.api.block.UndoList;
-import com.elmakers.mine.bukkit.api.spell.SpellCategory;
+import javax.annotation.Nullable;
+
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
@@ -13,6 +13,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
+import com.elmakers.mine.bukkit.api.block.UndoList;
+import com.elmakers.mine.bukkit.api.spell.SpellCategory;
 import com.elmakers.mine.bukkit.api.spell.SpellTemplate;
 import com.elmakers.mine.bukkit.api.wand.LostWand;
 import com.elmakers.mine.bukkit.api.wand.Wand;
@@ -281,14 +283,17 @@ public interface MagicAPI {
      * @param magicItemKey The template key, may be a wand, spell, etc.
      * @return An ItemStack representing the magic item.
      */
+    @Nullable
     ItemStack createItem(String magicItemKey);
-    ItemStack createItem(String magicItemKey, Mage mage);
+    @Nullable
+    ItemStack createItem(String magicItemKey, @Nullable Mage mage);
 
     /**
      * Create a generic version of an item with no extra data.
      * @param magicItemKey The template key, may be a wand, spell, etc.
      * @return The specified item.
      */
+    @Nullable
     ItemStack createGenericItem(String magicItemKey);
 
     /**
@@ -339,6 +344,7 @@ public interface MagicAPI {
      * @param wandKey The template key, or blank for a default wand.
      * @return A new Wand instance, with a useable ItemStack.
      */
+    @Nullable
     Wand createWand(String wandKey);
 
     /**
@@ -367,6 +373,7 @@ public interface MagicAPI {
      * @param item The item to use as the wand's icon.
      * @return The wand instance, or null on error.
      */
+    @Nullable
     Wand createWand(ItemStack item);
 
     /**
@@ -422,6 +429,7 @@ public interface MagicAPI {
      * @param item The item to inspect
      * @return The key of the Spell represented by this item.
      */
+    @Nullable
     String getSpell(ItemStack item);
 
     /**
@@ -430,6 +438,7 @@ public interface MagicAPI {
      * @param item The item to inspect
      * @return The key of the material brush represented by this item.
      */
+    @Nullable
     String getBrush(ItemStack item);
 
     /**
@@ -441,6 +450,7 @@ public interface MagicAPI {
      * @param spellKey The Spell to create an item for.
      * @return A new ItemStack, or null on error.
      */
+    @Nullable
     ItemStack createSpellItem(String spellKey);
 
     /**
@@ -452,6 +462,7 @@ public interface MagicAPI {
      * @param brushKey The Material brush to create an item for.
      * @return A new ItemStack, or null on error.
      */
+    @Nullable
     ItemStack createBrushItem(String brushKey);
 
     /**
@@ -529,6 +540,7 @@ public interface MagicAPI {
      * @param key The key of the SpellTemplate to look up.
      * @return The requested SpellTemplate, or null on failure.
      */
+    @Nullable
     SpellTemplate getSpellTemplate(String key);
 
     /**

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/Messages.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/magic/Messages.java
@@ -1,13 +1,16 @@
 package com.elmakers.mine.bukkit.api.magic;
 
-import org.bukkit.inventory.ItemStack;
-
 import java.util.Collection;
 import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.inventory.ItemStack;
 
 public interface Messages {
     boolean containsKey(String key);
     String get(String key);
+    @Nullable
     String getRandomized(String key);
     String get(String key, String defaultValue);
     List<String> getAll(String path);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/maps/MapController.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/maps/MapController.java
@@ -1,8 +1,10 @@
 package com.elmakers.mine.bukkit.api.maps;
 
-import org.bukkit.inventory.ItemStack;
-
 import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.inventory.ItemStack;
 
 public interface MapController {
     List<URLMap> getAll();
@@ -10,6 +12,7 @@ public interface MapController {
     void loadMap(String world, short id, String url, String name, int x, int y, int width, int height, Integer priority);
     ItemStack getURLItem(String world, String url, String name, int x, int y, int width, int height, Integer priority);
     void forceReloadPlayerPortrait(String worldName, String playerName);
+    @Nullable
     ItemStack getPlayerPortrait(String worldName, String playerName, Integer priority, String photoName);
     ItemStack getMapItem(short id);
     boolean hasMap(short id);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/MageSpell.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/MageSpell.java
@@ -1,5 +1,7 @@
 package com.elmakers.mine.bukkit.api.spell;
 
+import javax.annotation.Nullable;
+
 import com.elmakers.mine.bukkit.api.data.SpellData;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MageController;
@@ -44,5 +46,6 @@ public interface MageSpell extends Spell, CostReducer {
     void tick();
     void initialize(MageController controller);
 
+    @Nullable
     Double getAttribute(String attributeKey);
 }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/Spell.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/Spell.java
@@ -1,14 +1,17 @@
 package com.elmakers.mine.bukkit.api.spell;
 
-import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.block.MaterialAndData;
-import com.elmakers.mine.bukkit.api.block.MaterialBrush;
-import com.elmakers.mine.bukkit.api.magic.MageController;
+import javax.annotation.Nullable;
+
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.util.Vector;
+
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.block.MaterialAndData;
+import com.elmakers.mine.bukkit.api.block.MaterialBrush;
+import com.elmakers.mine.bukkit.api.magic.MageController;
 
 /**
  * Represents a Spell that may be cast by a Mage.
@@ -29,11 +32,14 @@ public interface Spell extends SpellTemplate {
     boolean cast(String[] parameters, Location defaultLocation);
     boolean cast(ConfigurationSection parameters, Location defaultLocation);
     boolean cast(ConfigurationSection parameters);
+    @Nullable
     Location getLocation();
     Entity getEntity();
     Location getEyeLocation();
     void target();
+    @Nullable
     Location getTargetLocation();
+    @Nullable
     Entity getTargetEntity();
     Vector getDirection();
     boolean canTarget(Entity entity);
@@ -43,6 +49,7 @@ public interface Spell extends SpellTemplate {
     void clearCooldown();
     void setRemainingCooldown(long ms);
     long getRemainingCooldown();
+    @Nullable
     CastingCost getRequiredCost();
     void messageTargets(String messageKey);
     void playEffects(String effectName);
@@ -56,8 +63,11 @@ public interface Spell extends SpellTemplate {
     void sendMessage(String message);
     void castMessage(String message);
     MaterialAndData getEffectMaterial();
+    @Nullable
     String getEffectParticle();
+    @Nullable
     Color getEffectColor();
+    @Nullable
     MaterialBrush getBrush();
     boolean brushIsErase();
     boolean isCancellable();
@@ -67,6 +77,7 @@ public interface Spell extends SpellTemplate {
     boolean cancelOnCastOther();
     String getMessage(String messageKey);
     boolean hasHandlerParameters(String handlerKey);
+    @Nullable
     ConfigurationSection getHandlerParameters(String handlerKey);
     long getProgressLevel();
     boolean cancelOnNoPermission();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/SpellTemplate.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/SpellTemplate.java
@@ -4,16 +4,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.api.magic.Messages;
-import com.elmakers.mine.bukkit.api.requirements.Requirement;
-import com.elmakers.mine.bukkit.api.wand.Wand;
+import javax.annotation.Nullable;
+
 import org.bukkit.Color;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.elmakers.mine.bukkit.api.block.MaterialAndData;
 import com.elmakers.mine.bukkit.api.effect.EffectPlayer;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.api.requirements.Requirement;
+import com.elmakers.mine.bukkit.api.wand.Wand;
 
 /**
  * A Spell template, as defined in the spells configuration files.
@@ -24,10 +26,13 @@ public interface SpellTemplate extends Comparable<SpellTemplate>, CostReducer {
     String getDescription();
     String getExtendedDescription();
     String getLevelDescription();
+    @Nullable
     String getCooldownDescription();
+    @Nullable
     String getMageCooldownDescription();
     String getKey();
     SpellKey getSpellKey();
+    @Nullable
     Color getColor();
     double getWorth();
     double getEarns();
@@ -42,13 +47,17 @@ public interface SpellTemplate extends Comparable<SpellTemplate>, CostReducer {
     String getDisabledIconURL();
     boolean hasIcon();
     boolean hasCastPermission(CommandSender sender);
+    @Nullable
     Collection<CastingCost> getCosts();
+    @Nullable
     Collection<CastingCost> getActiveCosts();
     Collection<EffectPlayer> getEffects(SpellResult result);
     Collection<EffectPlayer> getEffects(String effectsKey);
     long getDuration();
+    @Nullable
     String getDurationDescription(Messages messages);
     long getCooldown();
+    @Nullable
     Spell createSpell();
     void loadTemplate(String key, ConfigurationSection node);
     void loadPrerequisites(ConfigurationSection node);
@@ -74,6 +83,7 @@ public interface SpellTemplate extends Comparable<SpellTemplate>, CostReducer {
     void addLore(Messages messages, Mage mage, Wand wand, List<String> lore);
     boolean hasTag(String tag);
     boolean hasAnyTag(Collection<String> tags);
+    @Nullable
     SpellTemplate getUpgrade();
 
     /**

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/TargetType.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/spell/TargetType.java
@@ -18,7 +18,7 @@ public enum TargetType {
     SELECT(false),
     SELECT_ENTITY(true);
 
-    private boolean targetEntities;
+    private final boolean targetEntities;
 
     TargetType(boolean targetEntities) {
         this.targetEntities = true;

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/Wand.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/Wand.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.spell.CooldownReducer;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
@@ -16,12 +14,14 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.block.MaterialAndData;
 import com.elmakers.mine.bukkit.api.magic.CasterProperties;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MageClass;
 import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.magic.MagicConfigurable;
+import com.elmakers.mine.bukkit.api.spell.CooldownReducer;
 import com.elmakers.mine.bukkit.api.spell.CostReducer;
 import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellKey;
@@ -49,6 +49,7 @@ public interface Wand extends CostReducer, CooldownReducer, CasterProperties {
     boolean organizeInventory(Mage mage);
     boolean alphabetizeInventory();
     boolean organizeInventory();
+    @Nullable
     ItemStack getItem();
     MaterialAndData getIcon();
     MaterialAndData getInactiveIcon();
@@ -65,7 +66,9 @@ public interface Wand extends CostReducer, CooldownReducer, CasterProperties {
     Wand duplicate();
     @Override
     Spell getSpell(String key);
+    @Nullable
     Spell getSpell(String key, Mage mage);
+    @Nullable
     SpellTemplate getSpellTemplate(String key);
     @Override
     boolean hasSpell(String key);
@@ -96,6 +99,7 @@ public interface Wand extends CostReducer, CooldownReducer, CasterProperties {
     boolean removeSpell(String key);
     String getActiveBrushKey();
     String getActiveSpellKey();
+    @Nullable
     Spell getActiveSpell();
     void setActiveBrush(String key);
     void setActiveSpell(String key);
@@ -231,8 +235,10 @@ public interface Wand extends CostReducer, CooldownReducer, CasterProperties {
     @Deprecated
     void activate(Mage mage);
 
+    @Nullable
     Color getEffectColor();
     String getEffectParticleName();
+    @Nullable
     Location getLocation();
     @Override
     Mage getMage();

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/WandTemplate.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/WandTemplate.java
@@ -1,12 +1,15 @@
 package com.elmakers.mine.bukkit.api.wand;
 
+import java.util.Collection;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.bukkit.configuration.ConfigurationSection;
+
 import com.elmakers.mine.bukkit.api.effect.EffectPlayer;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MagicProperties;
-import org.bukkit.configuration.ConfigurationSection;
-
-import java.util.Collection;
-import java.util.Set;
 
 public interface WandTemplate extends MagicProperties {
     String getKey();
@@ -15,12 +18,14 @@ public interface WandTemplate extends MagicProperties {
     boolean hasTag(String tag);
     String getCreatorId();
     String getCreator();
+    @Nullable
     WandTemplate getMigrateTemplate();
     String migrateIcon(String icon);
     boolean isRestorable();
     Set<String> getCategories();
     ConfigurationSection getAttributes();
     String getAttributeSlot();
+    @Nullable
     WandTemplate getParent();
 
     boolean playEffects(Wand wand, String key);

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/WandUpgradePath.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/wand/WandUpgradePath.java
@@ -3,6 +3,7 @@ package com.elmakers.mine.bukkit.api.wand;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.ProgressionPath;
@@ -19,6 +20,7 @@ public interface WandUpgradePath extends ProgressionPath {
     boolean checkUpgradeRequirements(Wand wand, Mage mage);
     @Override
     Set<String> getTags();
+    @Nullable
     WandUpgradePath getUpgrade();
     void upgrade(@Nonnull Wand wand, Mage mage);
     void checkMigration(Wand wand);

--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,37 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.3</version>
 				<configuration>
+					<compilerId>javac-with-errorprone</compilerId>
+					<forceJavacCompilerUse>true</forceJavacCompilerUse>
+
 					<source>${version.java}</source>
 					<target>${version.java}</target>
-					<compilerArgument>-Xlint:all,-serial,-fallthrough</compilerArgument>
+
+					<compilerArgs>
+						<arg>-Xlint:all,-serial,-fallthrough</arg>
+						<!-- <arg>-Xep:FieldMissingNullable:ERROR</arg>  -->
+						<arg>-Xep:ReturnMissingNullable:ERROR</arg>
+						<arg>-Xep:RemoveUnusedImports:ERROR</arg>
+					</compilerArgs>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-compiler-javac-errorprone</artifactId>
+						<version>2.8.3</version>
+					</dependency>
+					<!-- override plexus-compiler-javac-errorprone's dependency on 
+					   Error Prone with the latest version -->
+					<dependency>
+						<groupId>com.google.errorprone</groupId>
+						<artifactId>error_prone_core</artifactId>
+						<version>2.2.0</version>
+						</dependency>
+					</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
**This is a WIP, do not merge yet**

Using google's error-prone javac plugin we can generate warnings for common bugs, similar to findbugs.

- Configured it to fail builds in the case of unused imports.
- Configured error-prone to require an `@Nullable` annotation in order to make `return null;` work.
  - Annotated all functions that can return null with `@Nullable`
  - Made `getMage` throw rather than return null, as it was recently annotated `@Nonnull`. Should we just fix the annotations back to `@Nullable`?

I can also configure it to require `@Nullable` on fields, but considering most of the existing code relies on null fields, this would probably be fairly pointless. I guess we should just annotate fields that are always guaranteed to be non null with `@Nonnull` and other fields `@Nullable` for new code, and ignore old code for now.

Another thing I ran into is the common pattern of returning null when arguments are invalid. This leads to a lot of things being `@Nullable` for only that reason, which makes it not as useful as a tool as it could be.

Anyways, this will hopefully improve the quality and maintainability of the codebase. And make my IDE go less crazy with warnings `:P`. If you have further suggestions for warnings I should configure, I would be glad to do so. (As of now I only raised the severity of two patterns from http://errorprone.info/bugpatterns to make the build fail)

In a future PR I might also look into using something like checkstyle to keep the style more consistent. (Damn tabs everywhere)