### PR TITLE
ClearChatAction

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChatAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChatAction.java
@@ -7,11 +7,13 @@ import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class ChatAction extends BaseSpellAction {
 
-    private String message;
+    @Nonnull
+    private String message =  "";
 
     private String translate(String str) {
         return ChatColor.translateAlternateColorCodes('&', str);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChatAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ChatAction.java
@@ -1,0 +1,73 @@
+package com.elmakers.mine.bukkit.action.builtin;
+
+import com.elmakers.mine.bukkit.action.BaseSpellAction;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Copyright Tyler Grissom 2018
+ */
+public class ChatAction extends BaseSpellAction {
+
+    private String message;
+
+    private List<String> randomizedMessages;
+
+    private boolean translateAltColorCodes;
+
+    private char altColorCode;
+
+    @Override
+    public void prepare(CastContext context, ConfigurationSection parameters) {
+        super.prepare(context, parameters);
+
+        this.message = parameters.getString("message");
+        this.randomizedMessages = parameters.getStringList("randomized_messages");
+        this.translateAltColorCodes = parameters.getBoolean("translate_alt_color_codes", true);
+
+        // Uhh, this is kind of terrible, but there doesn't appear to be a FileConfiguration#getChar or similar
+
+        this.altColorCode = parameters.getString("alt_color_code", "&").charAt(0);
+    }
+
+    @Override
+    public SpellResult perform(CastContext context) {
+        if (!(context.getTargetEntity() instanceof Player)) return null;
+
+        Player p = ((Player) context.getTargetEntity());
+
+        if (randomizedMessages == null || randomizedMessages.isEmpty()) {
+            if (message == null) return SpellResult.FAIL;
+
+            if (translateAltColorCodes) message = ChatColor.translateAlternateColorCodes(altColorCode, message);
+
+            p.chat(message);
+        } else {
+            if (translateAltColorCodes) {
+                for (int i = 0; i < randomizedMessages.size(); i++) {
+                    randomizedMessages.set(i, ChatColor.translateAlternateColorCodes(altColorCode, randomizedMessages.get(i)));
+                }
+            }
+
+            p.chat(randomizedMessages.get(ThreadLocalRandom.current().nextInt(randomizedMessages.size())));
+        }
+
+        return SpellResult.CAST;
+    }
+
+    @Override
+    public boolean requiresTarget() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresTargetEntity() {
+        return true;
+    }
+}

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ClearChatAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ClearChatAction.java
@@ -1,0 +1,57 @@
+package com.elmakers.mine.bukkit.action.builtin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import com.elmakers.mine.bukkit.action.BaseSpellAction;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+
+/**
+ * Copyright (c) 2013-2018 Tyler Grissom
+ */
+public class ClearChatAction extends BaseSpellAction {
+
+    private String message;
+    private int messageCount;
+
+    @Override
+    public void prepare(CastContext context, ConfigurationSection parameters) {
+        super.prepare(context, parameters);
+
+        Messages messages = context.getController().getMessages();
+        String messageEntry = parameters.getString("message");
+
+        this.message = ChatColor.translateAlternateColorCodes('&', messages.get(messageEntry, messageEntry));
+        this.messageCount = parameters.getInt("message_count", 100);
+
+        if (messageCount <= 0) {
+            this.messageCount = 1;
+        }
+    }
+
+    @Override
+    public SpellResult perform(CastContext context) {
+        if (!(context.getTargetEntity() instanceof Player)) return SpellResult.PLAYER_REQUIRED;
+
+        Player p = ((Player) context.getTargetEntity());
+
+        for (int i = 0; i < messageCount; i++) {
+            p.sendMessage(message);
+        }
+
+        return SpellResult.CAST;
+    }
+
+    @Override
+    public boolean requiresTarget() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresTargetEntity() {
+        return true;
+    }
+}

--- a/Magic/src/main/resources/defaults/messages/spells.yml
+++ b/Magic/src/main/resources/defaults/messages/spells.yml
@@ -1140,6 +1140,7 @@ spells:
         cast: You transmute your structure to $material
     masterattack:
         name: Master Blast
+        description: "A long-range attack that can only be performed when your health is full"
         insufficient_resources: ""
         cooldown: ""
     missile:
@@ -1576,7 +1577,7 @@ spells:
       description: Randomly teleport to a nearby location
     backflip:
       name: Backflip
-      descripttion: Quickly move backwards to evade your foes
+      description: Quickly move backwards to evade your foes
       fail: "a:There's nowhere to go!"
     birth_hunter:
       name: Create Hunter
@@ -1617,6 +1618,7 @@ spells:
       description: "Add the sharpness enchantment to your magic sword."
     magictorch:
       name: Magic Torch
+      description: A light that follows you around
     wandbuffshop:
       name: Wand Buffs
       description: "Add buffs to your wand.\nThese are only active while you are holding your wand."


### PR DESCRIPTION
Added ClearChatAction as Nathan and I discussed on RPG MC Central. I put in the `message` and `message_count` fields in there because I believe that there may be some use cases for people who wish to fine tune their chat clearing.

As per Nathan's suggestion, I removed the `target_source` and `global` fields so that you can simply pair this action with compounds without confusion.