### PR TITLE
Added BookAction

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -4,6 +4,7 @@ import java.util.*;
 import javax.annotation.Nonnull;
 
 import org.bukkit.Material;
+import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -59,7 +60,7 @@ public class BookAction extends BaseSpellAction {
                 str = str.replace(entry.getKey(), entry.getValue());
             }
 
-            newContents.add(str);
+            newContents.add(ChatColor.translateAlternateColorCodes('&', str));
         }
 
         return newContents;
@@ -73,8 +74,8 @@ public class BookAction extends BaseSpellAction {
         String titleParam = parameters.getString("title");
         String authorParam = parameters.getString("author");
 
-        title = messages.get(titleParam, titleParam);
-        author = messages.get(authorParam, authorParam);
+        title = messages.get(titleParam, ChatColor.translateAlternateColorCodes('&', titleParam));
+        author = messages.get(authorParam, ChatColor.translateAlternateColorCodes('&', authorParam));
         contents = parameters.getStringList("contents");
     }
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -26,9 +26,11 @@ public class BookAction extends BaseSpellAction {
         ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
         BookMeta meta = (BookMeta) book.getItemMeta();
 
+        contents = replaceContents(context, targetMage);
+        
         meta.setTitle(title);
         meta.setAuthor(author);
-        meta.setPages(replaceContents(context, targetMage));
+        meta.setPages(contents);
 
         book.setItemMeta(meta);
 
@@ -90,9 +92,6 @@ public class BookAction extends BaseSpellAction {
         }
 
         Mage targetMage = context.getController().getMage(context.getTargetEntity());
-
-        contents = replaceContents(context, targetMage);
-
         ItemStack book = createBook(context, targetMage);
 
         targetMage.giveItem(book);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -19,7 +19,7 @@ public class BookAction extends BaseSpellAction {
 
     @Nonnull
     private String title = "", author = "";
-    private List<String> contents = new ArrayList<>();
+    private List<String> contents;
 
     private ItemStack createBook(CastContext context, Mage targetMage) {
         ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
@@ -75,6 +75,7 @@ public class BookAction extends BaseSpellAction {
 
         title = messages.get(titleParam, titleParam);
         author = messages.get(authorParam, authorParam);
+        contents = parameters.getStringList("contents");
     }
 
     @Override

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -1,18 +1,19 @@
 package com.elmakers.mine.bukkit.action.builtin;
 
-import com.elmakers.mine.bukkit.action.BaseSpellAction;
-import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.api.magic.Messages;
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import java.util.*;
+import javax.annotation.Nonnull;
+
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
-import javax.annotation.Nonnull;
-import java.util.*;
+import com.elmakers.mine.bukkit.action.BaseSpellAction;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
 
 public class BookAction extends BaseSpellAction {
 

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -1,25 +1,23 @@
 package com.elmakers.mine.bukkit.action.builtin;
 
-import java.util.*;
-import javax.annotation.Nonnull;
-
+import com.elmakers.mine.bukkit.action.BaseSpellAction;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
-import com.elmakers.mine.bukkit.action.BaseSpellAction;
-import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.api.magic.Messages;
-import com.elmakers.mine.bukkit.api.spell.SpellResult;
+import javax.annotation.Nonnull;
+import java.util.*;
 
 public class BookAction extends BaseSpellAction {
 
     @Nonnull
     private String title = "", author = "";
-    @Nonnull
     private List<String> contents = new ArrayList<>();
 
     private ItemStack createBook(CastContext context, Mage targetMage) {
@@ -42,7 +40,7 @@ public class BookAction extends BaseSpellAction {
         replacements.put("@td", targetMage.getDisplayName());
 
         Set<String> attributes = context.getController().getAttributes();
-        Set<String> currencies = context.getController().getCustomCurrencies();
+        Set<String> currencies = context.getController().getCurrencyKeys();
 
         for (String attr : attributes) {
             replacements.put("$attribute_" + attr, String.valueOf(targetMage.getProperties().getAttribute(attr)));

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/BookAction.java
@@ -1,0 +1,111 @@
+package com.elmakers.mine.bukkit.action.builtin;
+
+import java.util.*;
+import javax.annotation.Nonnull;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+
+import com.elmakers.mine.bukkit.action.BaseSpellAction;
+import com.elmakers.mine.bukkit.api.action.CastContext;
+import com.elmakers.mine.bukkit.api.magic.Mage;
+import com.elmakers.mine.bukkit.api.magic.Messages;
+import com.elmakers.mine.bukkit.api.spell.SpellResult;
+
+public class BookAction extends BaseSpellAction {
+
+    @Nonnull
+    private String title = "", author = "";
+    @Nonnull
+    private List<String> contents = new ArrayList<>();
+
+    private ItemStack createBook(CastContext context, Mage targetMage) {
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta meta = (BookMeta) book.getItemMeta();
+
+        meta.setTitle(title);
+        meta.setAuthor(author);
+        meta.setPages(replaceContents(context, targetMage));
+
+        book.setItemMeta(meta);
+
+        return book;
+    }
+
+    private List<String> replaceContents(CastContext context, Mage targetMage) {
+        Map<String, String> replacements = new HashMap<>();
+
+        replacements.put("@tn", targetMage.getName());
+        replacements.put("@td", targetMage.getDisplayName());
+
+        Set<String> attributes = context.getController().getAttributes();
+        Set<String> currencies = context.getController().getCustomCurrencies();
+
+        for (String attr : attributes) {
+            replacements.put("$attribute_" + attr, String.valueOf(targetMage.getProperties().getAttribute(attr)));
+        }
+
+        for (String currency : currencies) {
+            replacements.put("$balance_" + currency, String.valueOf(targetMage.getCurrency(currency)));
+        }
+
+        List<String> copy = new ArrayList<>(contents);
+        List<String> newContents = new ArrayList<>();
+
+        for (String str : copy) {
+            for (Map.Entry<String, String> entry : replacements.entrySet()) {
+                str = str.replace(entry.getKey(), entry.getValue());
+            }
+
+            newContents.add(str);
+        }
+
+        return newContents;
+    }
+
+    @Override
+    public void prepare(CastContext context, ConfigurationSection parameters) {
+        super.prepare(context, parameters);
+
+        Messages messages = context.getController().getMessages();
+        String titleParam = parameters.getString("title");
+        String authorParam = parameters.getString("author");
+
+        title = messages.get(titleParam, titleParam);
+        author = messages.get(authorParam, authorParam);
+    }
+
+    @Override
+    public SpellResult perform(CastContext context) {
+        if (context.getTargetEntity() == null) {
+            return SpellResult.NO_TARGET;
+        }
+
+        if (!(context.getTargetEntity() instanceof InventoryHolder)) {
+            return SpellResult.FAIL;
+        }
+
+        Mage targetMage = context.getController().getMage(context.getTargetEntity());
+
+        contents = replaceContents(context, targetMage);
+
+        ItemStack book = createBook(context, targetMage);
+
+        targetMage.giveItem(book);
+
+        return SpellResult.CAST;
+    }
+
+    @Override
+    public boolean requiresTarget() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresTargetEntity() {
+        return true;
+    }
+}


### PR DESCRIPTION
I've implemented the BookAction that Nathan and I discussed over Discord. This supports replacements for custom currency, attribute values, and target names, though I'm not sure about the format. This code *should* work in theory but it is largely untested and is going to need some revisions (it's much better than the original versions haha.)

I'm not entirely happy with how the flow goes between replacing contents, creating the book, and all that so I'm definitely receptive to suggestions there. I'd also like to expand the number of replacements available.

A use-case for this would be for character sheets where the player's attributes, currency, and more could be displayed in a more visually appealing way.