### PR TITLE
Added ability to bypass mana max in ModifyManaAction

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
@@ -1,12 +1,5 @@
 package com.elmakers.mine.bukkit.action.builtin;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-
 import com.elmakers.mine.bukkit.action.BaseSpellAction;
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.magic.CasterProperties;
@@ -17,17 +10,25 @@ import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.spell.BaseSpell;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 public class ModifyManaAction extends BaseSpellAction
 {
     private int mana;
     private boolean fillMana;
+    private boolean bypassManaMax;
 
     @Override
     public void prepare(CastContext context, ConfigurationSection parameters) {
         super.prepare(context, parameters);
         mana = parameters.getInt("mana", 1);
         fillMana = parameters.getBoolean("fill_mana", false);
+        bypassManaMax = parameters.getBoolean("bypass_mana_max", false);
     }
 
     @Override
@@ -59,8 +60,10 @@ public class ModifyManaAction extends BaseSpellAction
             return SpellResult.NO_TARGET;
         }
         int manaMax = caster.getEffectiveManaMax();
-        if (mana > 0 && currentMana >= manaMax) {
-            return SpellResult.NO_TARGET;
+        if (!bypassManaMax) {
+            if (mana > 0 && currentMana >= manaMax) {
+                return SpellResult.NO_TARGET;
+            }
         }
         if (fillMana) {
             currentMana = manaMax;
@@ -68,6 +71,9 @@ public class ModifyManaAction extends BaseSpellAction
             currentMana = Math.min(Math.max(0, currentMana + mana), manaMax);
         }
         caster.setMana((float)currentMana);
+        if (bypassManaMax && currentMana > manaMax) {
+            caster.setManaMax((int)currentMana);
+        }
         mage.updateMana();
         return SpellResult.CAST;
     }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
@@ -1,5 +1,12 @@
 package com.elmakers.mine.bukkit.action.builtin;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
 import com.elmakers.mine.bukkit.action.BaseSpellAction;
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.magic.CasterProperties;
@@ -10,12 +17,6 @@ import com.elmakers.mine.bukkit.api.spell.Spell;
 import com.elmakers.mine.bukkit.api.spell.SpellResult;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.spell.BaseSpell;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 public class ModifyManaAction extends BaseSpellAction
 {

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/ModifyManaAction.java
@@ -61,10 +61,8 @@ public class ModifyManaAction extends BaseSpellAction
             return SpellResult.NO_TARGET;
         }
         int manaMax = caster.getEffectiveManaMax();
-        if (!bypassManaMax) {
-            if (mana > 0 && currentMana >= manaMax) {
-                return SpellResult.NO_TARGET;
-            }
+        if (!bypassManaMax && mana > 0 && currentMana >= manaMax) {
+            return SpellResult.NO_TARGET;
         }
         if (fillMana) {
             currentMana = manaMax;


### PR DESCRIPTION
Submitting this quick PR based on a feature I thought might be useful. I'd like to sell a potion in BetterPotter that would buff max mana but couldn't because the ModifyManaAction caps no matter what. 

A `bypass_mana_max` flag could be useful in my opinion but perhaps wasn't implemented for a reason? Let me know!