### PR TITLE
Fix sounds in spells/default.yml & mount.yml; fix mine|6 tool parameter

### DIFF
--- a/Magic/src/main/resources/defaults/spells/default.yml
+++ b/Magic/src/main/resources/defaults/spells/default.yml
@@ -29,28 +29,28 @@ default:
        fail:
        - class: EffectSingle
          location: origin
-         sound: block_note_basedrum
+         sound: block_note_block_basedrum
          sound_broadcast: false
          sound_volume: 0.8
          sound_pitch: 1.2
        insufficient_resources:
        - class: EffectSingle
          location: origin
-         sound: block_note_bass
+         sound: block_note_block_bass
          sound_broadcast: false
          sound_volume: 0.7
          sound_pitch: 1.2
        insufficient_permission:
        - class: EffectSingle
          location: origin
-         sound: block_note_bass
+         sound: block_note_block_bass
          sound_broadcast: false
          sound_volume: 0.9
          sound_pitch: 1.5
        cooldown:
        - class: EffectSingle
          location: origin
-         sound: block_note_basedrum
+         sound: block_note_block_basedrum
          sound_broadcast: false
          sound_volume: 0.6
          sound_pitch: 0.8

--- a/Magic/src/main/resources/examples/survival/spells/mine.yml
+++ b/Magic/src/main/resources/examples/survival/spells/mine.yml
@@ -71,5 +71,5 @@ mine|5:
 
 mine|6:
   parameters:
-    tool: loot3_pickaxe
+    tool: loot5_pickaxe
 

--- a/Magic/src/main/resources/examples/survival/spells/mount.yml
+++ b/Magic/src/main/resources/examples/survival/spells/mount.yml
@@ -16,7 +16,7 @@ mount:
     effects:
         cast:
         -  class: EffectSingle
-           sound: entity_irongolem_hurt
+           sound: entity_iron_golem_hurt
         -  class: EffectSingle
            effectlib:
              class: ConeEffect


### PR DESCRIPTION
Fix spells/default.yml note block sounds
Should use block_note_block instead of block_note

Fix level 6 mine spell tool parameter
Should use loot5_pickaxe as a tool instead of loot3_pickaxe which is already used in level 5

Fix mount spell cast sound
Should use iron_golem instead of irongolem