### PR TITLE
1st part of changes/additions to the survival spells

### DIFF
--- a/Magic/src/main/resources/examples/survival/messages/spells.yml
+++ b/Magic/src/main/resources/examples/survival/messages/spells.yml
@@ -135,6 +135,7 @@ spells:
         name: Singularity
         description: Create a black hole
         cast_player_message: "a:You got sucked into a black hole"
+        upgrade_description: "Increased radius, duration and damage"
     arrow:
         name: Arrow
         description: Fire a magic arrow
@@ -279,7 +280,7 @@ spells:
     shuriken:
         name: Shuriken
         description: Throw a bouncing projectile
-        upgrade_description: "Increased damage"
+        upgrade_description: "Increased target hit count and duration"
     wave:
         name: Wave
         description: Unleash a concussive wave
@@ -308,11 +309,13 @@ spells:
         description: Call a monster to your side
         deactivate: You release your monster
         cast: You summon a monster
+        upgrade_description: "Increased duration, unlocked new mob types"
     mob:
         name: Mob
         description: Summon a mob of monsters
         deactivate: You release your mob
         cast: You summon $count monster(s)
+        upgrade_description: "Increased duration and mob count, unlocked new mob types. Decreased cooldown."
     portal:
         name: Portal
         description: Create a temporary portal
@@ -406,6 +409,11 @@ spells:
     lightning|3:
         upgrade_description: "More lightning"
         cast: Ka-POW!
+    sunstrike:
+        name: Sunstrike
+        description: Summon a focused sunbeam
+        usage: Only works during the daytime.\nDeals more damage at noon
+        cast: You summoned a sunbeam!
     smite:
         name: Smite
         description: Strike down your target
@@ -880,6 +888,7 @@ spells:
         description: Blast through blocks and multiple targets
         cast: You fire a rail at $target
         no_target: You fire off a rail
+        upgrade_description: "Increased range and target hit count. Decreased cooldown and manacost."
     testdummy:
         name: Test Dummy
         description: Spawn a poor test dummy
@@ -1038,6 +1047,8 @@ spells:
         upgrade_description: "Larger search radius"
     tracking|4:
         upgrade_description: "Sneak-cast to look only for players"
+    tracking|5:
+        upgrade_description: "Aim down and cast to highlight all mobs/players within a 16 block radius"
     enchantwand:
         name: Upgrade Wand
         description: Add levels to your wand

--- a/Magic/src/main/resources/examples/survival/spells/mob.yml
+++ b/Magic/src/main/resources/examples/survival/spells/mob.yml
@@ -7,6 +7,8 @@ mob:
     category: dark
     pvp_restricted: true
     worth: 300
+    upgrade_required_casts: 50
+    upgrade_required_path: master
     actions:
       cast:
       # We are going to force the spawned mob to target the entity we originally targeted
@@ -48,7 +50,7 @@ mob:
            effectlib:
                class: Smoke
                duration: 100
-               particle: end_rod
+               particle: spell
                particle_count: 5
                particle_offset_x: 0.5
                particle_offset_y: 0.5
@@ -66,30 +68,65 @@ mob:
             particle_offset_y: 0.5
             particle_offset_z: 0.5
     parameters:
+        allow_replacement: false
         entity_types:
             zombie: 100
             skeleton: 100
             spider: 110
-            creeper: 30
-            witch: 20
-            slime: 20
-            blaze: 15
-            bat: 15
-            magma_cube: 10
-            pig_zombie: 10
-            cave_spider: 10
-            silverfish: 8
-            ghast: 5
-            enderman: 5
-            giant: 1
+            zombified_piglin: 50
+            zombie_villager: 80
+            husk: 30
+            stray: 30
         target_type: LivingEntity
         allow_max_range: false
         range: 32
-        cooldown: 45000
-        undo: 30000
-        repeat: 20
+        cooldown: 50000
+        undo: 15000
+        repeat: 10
         radius: 16
         delay: 500
     costs:
         mana: 100
+
+mob|2:
+  inherit: false
+  parameters:
+        repeat: 15
+        cooldown: 40000
+        undo: 20000
+        entity_types:
+            zombie: 40
+            skeleton: 60
+            spider: 45
+            zombified_piglin: 50
+            zombie_villager: 30
+            husk: 60
+            stray: 40
+            creeper: 40
+            cave_spider: 30
+  costs:
+    mana: 150
+
+mob|3:
+  inherit: false
+  parameters:
+        repeat: 20
+        cooldown: 30000
+        undo: 25000
+        entity_types:
+            zombie: 20
+            skeleton: 30
+            spider: 20
+            zombified_piglin: 30
+            zombie_villager: 20
+            husk: 40
+            stray: 45
+            creeper: 50
+            enderman: 20
+            cave_spider: 25
+            blaze: 25
+            ghast: 10
+            zoglin: 10
+  costs:
+    mana: 200
 

--- a/Magic/src/main/resources/examples/survival/spells/monster.yml
+++ b/Magic/src/main/resources/examples/survival/spells/monster.yml
@@ -7,6 +7,8 @@ monster:
     category: dark
     pvp_restricted: true
     worth: 150
+    upgrade_required_casts: 50
+    upgrade_required_path: student
     actions:
       cast:
       # We are going to force the spawned mob to target the entity we originally targeted
@@ -64,26 +66,52 @@ monster:
             particle_offset_y: 0.5
             particle_offset_z: 0.5
     parameters:
+        allow_replacement: false
         target_type: LivingEntity
         allow_max_range: false
         cooldown: 30000
         range: 32
-        undo: 20000
+        undo: 10000
         entity_types:
             zombie: 100
             skeleton: 100
             spider: 110
-            creeper: 30
-            witch: 20
-            blaze: 15
-            bat: 15
-            magma_cube: 10
-            pig_zombie: 10
-            cave_spider: 10
-            silverfish: 8
-            ghast: 5
-            enderman: 5
-            giant: 1
+            zombified_piglin: 50
+            zombie_villager: 80
+            husk: 30
+            stray: 30
     costs:
         mana: 40
+
+monster|2:
+  parameters:
+        undo: 15000
+        entity_types:
+            zombie: 40
+            skeleton: 60
+            spider: 45
+            zombified_piglin: 50
+            zombie_villager: 30
+            husk: 60
+            stray: 40
+            creeper: 40
+            cave_spider: 30
+
+monster|3:
+  parameters:
+        undo: 20000
+        entity_types:
+            zombie: 20
+            skeleton: 30
+            spider: 20
+            zombified_piglin: 30
+            zombie_villager: 20
+            husk: 40
+            stray: 45
+            creeper: 50
+            enderman: 20
+            cave_spider: 25
+            blaze: 25
+            ghast: 10
+            zoglin: 10
 

--- a/Magic/src/main/resources/examples/survival/spells/railgun.yml
+++ b/Magic/src/main/resources/examples/survival/spells/railgun.yml
@@ -10,6 +10,8 @@ railgun:
     brush_effects: false
     require_break: false
     require_build: false
+    upgrade_required_casts: 75
+    upgrade_required_path: master
     actions:
         cast:
         - class: CustomProjectile
@@ -125,10 +127,10 @@ railgun:
         break_durability: 1000
         allow_max_range: true
         velocity: 1000
-        range: 80
+        range: 40
         hitbox: true
-        block_hit_count: 4
-        entity_hit_count: 5
+        block_hit_count: 3
+        entity_hit_count: 2
         target_type: Damageable
         player_damage: 6
         entity_damage: 8
@@ -139,4 +141,22 @@ railgun:
         transparent: all_air,water,stationary_water
     costs:
         mana: 150
+
+railgun|2:
+    parameters:
+        range: 60
+        block_hit_count: 5
+        entity_hit_count: 3
+        cooldown: 8000
+    costs:
+        mana: 125
+
+railgun|3:
+    parameters:
+        range: 80
+        block_hit_count: 7
+        entity_hit_count: 4
+        cooldown: 6000
+    costs:
+        mana: 100
 

--- a/Magic/src/main/resources/examples/survival/spells/shuriken.yml
+++ b/Magic/src/main/resources/examples/survival/spells/shuriken.yml
@@ -1,4 +1,6 @@
 shuriken:
+    # This has been added automatically so that anything you remove here does not get inherited back in from the default configs
+    inherit: false
     icon: emerald{CustomModelData:18002}
     icon_disabled: emerald{CustomModelData:18003}
     legacy_icon: spell_icon:194
@@ -13,9 +15,8 @@ shuriken:
         cast:
         -  class: CustomProjectile
            actions:
-           -  class: AreaOfEffect
-              actions:
-              - class: Damage
+           -  class: ModifyNoDamageTicks
+           -  class: Damage
     effects:
         tick:
         -  particle: block_crack
@@ -46,34 +47,16 @@ shuriken:
         hit_entity:
         -  sound: entity_arrow_hit
            sound_pitch: 1.6
-        hit:
-        -  class: EffectSingle
-           sound: magic.shimmer_big
-           location: target
-           material: stained_clay:15
-           effectlib:
-             class: Modified
-             iterations: 10
-             parameters:
-              radius: "(t/i)*5"
-             effect:
-               class: HelixEffect
-               particle: block_crack
-               particles: 20
-               particle_count: 4
-               particle_offset_x: 1
-               particle_offset_y: 0.05
-               particle_offset_z: 1
     parameters:
         range: 32
         target_type: Damageable
         reflective: solid
+        transparent: transparent
         cooldown: 8000
         velocity: 20
-        gravity: 0.05
-        damage: 2
-        radius: 3
-        lifetime: 10000
+        entity_hit_count: 3
+        damage: 3
+        lifetime: 8000
         hit_on_miss: true
     costs:
         mana: 80
@@ -82,11 +65,11 @@ shuriken|2:
     upgrade_required_path: master
     upgrade_required_casts: 50
     parameters:
-        damage: 3
-        radius: 4
+        lifetime: 10000
+        entity_hit_count: 5
 
 shuriken|3:
     parameters:
-        damage: 4
-        radius: 5
+        lifetime: 12000
+        entity_hit_count: 7
 

--- a/Magic/src/main/resources/examples/survival/spells/singularity.yml
+++ b/Magic/src/main/resources/examples/survival/spells/singularity.yml
@@ -12,57 +12,48 @@ singularity:
     upgrade_required_casts: 50
     actions:
         cast:
-        # Start with a custom projectile
-        - class: CustomProjectile
-          actions:
-            # This switches the "brush" to erase
-            # Needed since the original brush was obsidian for ThrowBlock
-          - class: Brush
-            ignore_result: true
-            brush: erase
+          - class: Sphere
             actions:
-            # First build a sphere
-            # Actions happen in order, so it stays here until
-            # the sphere finishes building
-            - class: Sphere
-              actions:
-              # Erase the block and spawn a falling block with an
-              # upward velocity
               - class: ModifyBlock
                 direction: 0,1,0
-            # Once the sphere is complete, we start a Repeat action
-            # This will perform the actions below "repeat" number of
-            # times (see parameters - repeat: 10)
-            #
-            # Note that you can mix parameters in here or in the main
-            # spell parameters. Ones in here will override.
-            # However, you can only override the ones in the base
-            # parameter list with /cast or /wand override
-            # so it's best to use those so you can tweak in-game.
-          - class: Repeat
+          - class: AreaOfEffect
             actions:
-            # Delay for a while
-            - class: Delay
-            # Do an AOE
-            - class: AreaOfEffect
-              actions:
-              # Pull (push: -1) entities inward
               - class: Velocity
-                ignore_result: true
-                push: -1
-                entity_speed: 0.7
-              - class: Damage
-              # Delay a bit more
-            - class: Delay
-              # AOE, push entities outward slightly
-            - class: AreaOfEffect
-              actions:
+          - class: Interval
+            interval: 200
+            actions:
+              - class: AreaOfEffect
+                actions:
+                  - class: Velocity
+                    speed: 0.25
+                    item_speed: 0.25
+                    entity_speed: 0.25
+          - class: AreaOfEffect
+            actions:
               - class: Velocity
-                ignore_result: true
-                push: 1
-                entity_speed: 0.1
+                push: 3
               - class: Damage
     effects:
+        cast_finish:
+        -  sound: entity_iron_golem_death
+           sound_pitch: 0.3
+           sound_volume: 0.2
+        -  sound: block_conduit_deactivate
+           sound_pitch: 0.7
+           sound_volume: 0.5
+           effectlib:
+             class: Modified
+             iterations: 3
+             duration: 150
+             parameters:
+               radius: 1.5 + (t/i) * 5
+             effect:
+               class: Sphere
+               particle: redstone
+               color: "#000000"
+               particle_size: 0.6
+               radius: 0.6
+               particles: 150
         cast:
         -  sound: entity_wither_shoot
            sound_pitch: 0.4
@@ -71,75 +62,73 @@ singularity:
            sound_pitch: 0.2
            sound_volume: 0.3
            location: origin
-        tick:
-        - location: target
-          particle: smoke_normal
-          particle_count: 8
-          particle_offset_x: 0.4
-          particle_offset_y: 0.4
-          particle_offset_z: 0.4
-        - location: target
-          particle: block_crack
-          material: obsidian
-          particle_count: 10
-          particle_offset_x: 0.6
-          particle_offset_y: 0.6
-          particle_offset_z: 0.6
-        hit:
-        - sound: block_conduit_deactivate
-          sound_pitch: 0.7
-          sound_volume: 0.5
+        -  sound: block_conduit_deactivate
+           sound_pitch: 0.7
+           sound_volume: 0.5
         -  sound: entity_bee_loop
            sound_pitch: 2
            location: target
         -  sound: entity_wither_death
            sound_pitch: 0.5
            location: target
+           target_location: block_center
+           effectlib:
+             class: Sphere
+             duration: $duration
+             iterations: $duration / 50
+             particle: redstone
+             color: "#000000"
+             particle_size: 1.5
+             radius: 1.5
+             particles: 250
         -  class: EffectSingle
            location: target
-           sound: magic.hit
-           effectlib:
-             class: SphereEffect
-             duration: $duration
-             particle: redstone
-             color: 010101
-             radius: 1
-             particles: 20
-        -  location: target
-           material: obsidian
+           target_location: block_center
            effectlib:
              class: Modified
              duration: $duration
+             iterations: $duration / 50
+             period: 3
              parameters:
-               radius: "sin(t/50)*5"
+               radius: "8(1-(t/i))"
+               rotation: t/10
              effect:
-               class: Sphere
-               particle: block_crack
-               color: 010101
-               particles: 20
-               particle_count: 4
-               particle_offset_x: 1
-               particle_offset_y: 1
-               particle_offset_z: 1
+               class: Helix
+               particle: redstone
+               color: "#000000"
+               particle_size: 0.6
+               particles: 70
+               curve: -2
     parameters:
       target_type: Entity
-      velocity: 10
-      gravity: 0.02
-      hitbox_size: 2
+      range: 12
+      target: block
+      allow_max_range: true
+      destructible: destructible,destructible2,destructible3
       undo: 15000
-      repeat: 15
-      delay: 250
       duration: 7000
       damage: 3
+      speed: 0.75
+      item_speed: 0.75
+      entity_speed: 0.75
+      brush: air
+      player_damage: 10
+      entity_damage: 15
       target_self_timeout: 2000
-      speed: 0.5
-      item_speed: 0.5
-      entity_speed: 0.5
+      target_self: true
+      push: -1
       falling: true
-      radius: 5
-      destructible: destructible,destructible2,destructible3
-      destructible_override: true
+      radius: 4
+      y_radius: 4
       cooldown: 30000
     costs:
         mana: 50
+
+singularity|2:
+  parameters:
+      radius: 6
+      y_radius: 6
+      player_damage: 15
+      entity_damage: 20
+      duration: 10000
 

--- a/Magic/src/main/resources/examples/survival/spells/sunstrike.yml
+++ b/Magic/src/main/resources/examples/survival/spells/sunstrike.yml
@@ -1,0 +1,80 @@
+sunstrike:
+  icon: honeycomb{CustomModelData:18001}
+  icon_disabled: honeycomb{CustomModelData:18002}
+  cast_on_no_target: false
+  category: master
+  pvp_restricted: true
+  actions:
+    cast:
+     - class: CheckRequirements
+       requirements:
+        - time:
+            min: 0
+            max: 12000
+       actions:
+        - class: Delay
+        - class: ChangeContext
+          source_at_target: true
+          source_offset: 0,100,0
+          actions:
+            - class: CustomProjectile
+              range: 255
+              actions:
+                - class: AreaOfEffect
+                  y_radius: 1
+                  actions:
+                    - class: Damage
+                    - class: Ignite
+  effects:
+    no_target: []
+    tick:
+      - location: target
+        particle: end_rod
+        particle_count: 15
+        particle_offset_x: 0.2
+        particle_offset_z: 0.2
+        particle_offset_y: 0.2
+        particle_data: 0.1
+    hit:
+      - location: target
+        sound: magic.burn
+        sound_pitch: 1.2
+        sound_volume: 0.8
+      - location: target
+        sound: magic.ignite
+        sound_pitch: 0.8
+        sound_volume: 0.5
+      - location: target
+        sound: block_beacon_deactivate
+        sound_pitch: 0.8
+        sound_volume: 1.5
+      - location: target
+        sound: entity_ender_dragon_hurt
+        sound_pitch: 0.8
+        sound_volume: 0.6
+    cast:
+    - location: target
+      effectlib:
+        class: Helix
+        radius: $radius
+        rotation: (t/i)*2
+        duration: 1000
+        iterations: 20
+      sound: magic.burn
+  parameters:
+    target: other
+    allow_max_range: true
+    cooldown: 60000
+    transparent: transparent_and_glass
+    target_type: LivingEntity
+    target_self: true
+    velocity: 500
+    radius: 2
+    delay: 1500
+    range: 16
+    duration: 5000
+    damage_type: FIRE
+    damage: max(5,sin(3.14159*time/12000)*21)
+  costs:
+    mana: 100
+

--- a/Magic/src/main/resources/examples/survival/spells/tracking.yml
+++ b/Magic/src/main/resources/examples/survival/spells/tracking.yml
@@ -50,19 +50,24 @@ tracking:
     costs:
         mana: 20
 
-tracking|2:
-    upgrade_required_path: apprentice
-    upgrade_required_casts: 30
-    parameters:
-        range: 64
-
-tracking|3:
-    upgrade_required_path: master
-    upgrade_required_casts: 40
-    parameters:
-        range: 128
-
 tracking|4:
+    upgrade_required_path: master
+    upgrade_required_casts: 50
     alternate_sneak_parameters:
         target_type: Player
+
+tracking|5:
+  actions:
+    alternate_down:
+      - class: AreaOfEffect
+        actions:
+          - class: PotionEffect
+  alternate_down_parameters:
+     target: self
+     target_type: LivingEntity
+     effect_glowing: 1
+     duration: 10000
+     cooldown: 15000
+     radius: 16
+     y_radius: 16
 


### PR DESCRIPTION
1) Railgun now has 3 levels:
Upgrade increases range and block/entity hit count, decreases cooldown and manacost
2) Slightly reworked mob spell. Now has 3 levels:
Spawns 10/15/20 mobs at each level. Upgrade decreases cooldown and duration, unlocks new mob types.
3) Reworked singularity. Now has 2 levels:
Now simply creates a small black hole at the target. Deals constant damage at the end. Upgrade increases radius, damage and duration.
4) Added tracking level 5:
Aim down and cast to highlight all mobs/players within a 16 block radius.
5) Monster spell now has 3 levels:
Upgrade unlocks new mob types and increases duration.
6) Completely reworked shuriken:
Now uses new ModifyNoDamageTicks action. Upgrade increases projectile's lifetime and hit count.
Very strong spell if been used inside small area. Can hit one entity multiple times, which can be used with other spells like Walls and Shell to create very powerful combo.
7) Added new Sunstrike spell (not in a spellshop by now):
Works only at daytime, deals 20 damage at noon (5 damage at sunrise and dusk) and puts entity on fire. Has small delay. Sunbeam can go through glass blocks, but can be reflected with Reflect and Shell. Doesn't deal damage if mob/player has Fire Resistance potion effect.