### PR TITLE
2nd part of additions/changes to survival spells

### DIFF
--- a/Magic/src/main/resources/examples/survival/messages/spells.yml
+++ b/Magic/src/main/resources/examples/survival/messages/spells.yml
@@ -219,7 +219,7 @@ spells:
     harden|2:
         upgrade_description: "Increased duration. Now converts to stone bricks"
     harden|3:
-        upgrade_description: "Increased duration. Now converts to smooth"
+        upgrade_description: "Increased duration. Now converts to smooth stone"
     harden|4:
         upgrade_description: "Increased duration. Now converts to polished blackstone"
     harden|5:

--- a/Magic/src/main/resources/examples/survival/messages/spells.yml
+++ b/Magic/src/main/resources/examples/survival/messages/spells.yml
@@ -46,6 +46,7 @@ spells:
         name: Silence
         description: Prevent your target from casting spells
         cast: You silence $target
+        upgrade_description: "Decreased manacost and cooldown, increased duration"
     curse:
         name: Curse
         description: Slows down and weakens the target
@@ -216,7 +217,13 @@ spells:
         description: Make the target blocks stronger
         cast: Hardened $count blocks
     harden|2:
-        upgrade_description: "Now converts to obsidian"
+        upgrade_description: "Increased duration. Now converts to stone bricks"
+    harden|3:
+        upgrade_description: "Increased duration. Now converts to smooth"
+    harden|4:
+        upgrade_description: "Increased duration. Now converts to polished blackstone"
+    harden|5:
+        upgrade_description: "Increased duration. Now converts to obsidian"
     disarm:
         name: Disarm
         description: Disarm your opponent
@@ -280,7 +287,7 @@ spells:
     shuriken:
         name: Shuriken
         description: Throw a bouncing projectile
-        upgrade_description: "Increased target hit count and duration"
+        upgrade_description: "Increased duration"
     wave:
         name: Wave
         description: Unleash a concussive wave
@@ -387,6 +394,7 @@ spells:
         name: Meteor Shower
         description: Fire death from above
         cast: You rain fire from the heavens
+        upgrade_description: "Decreased cooldown, increased shards count"
     bomb:
         name: Carpet Bomb
         description: Rain death from above
@@ -414,6 +422,7 @@ spells:
         description: Summon a focused sunbeam
         usage: Only works during the daytime.\nDeals more damage at noon
         cast: You summoned a sunbeam!
+        upgrade_description: "Increased max damage, decreased delay"
     smite:
         name: Smite
         description: Strike down your target
@@ -650,6 +659,7 @@ spells:
         name: Workbench
         description: Crafting on the go
         cast: Get to work!
+        upgrade_description: "Decreased cooldown and manacost"
     superlaser:
         name: SuperLaser
         description: Permanently destroy a line of blocks
@@ -714,8 +724,7 @@ spells:
         description: Teleport you to other players
         usage: Aim down and cast to manage friends
         alternate_down_no_target: "&4No one is around"
-        no_target: |2-
-
+        no_target: |-
           &4No one is around to teleport to
           &3Aim down and cast to send friend requests!
         cast_to_player: Teleporting you to $target
@@ -888,7 +897,7 @@ spells:
         description: Blast through blocks and multiple targets
         cast: You fire a rail at $target
         no_target: You fire off a rail
-        upgrade_description: "Increased range and target hit count. Decreased cooldown and manacost."
+        upgrade_description: "Increased range and target hit count. Decreased cooldown and manacost"
     testdummy:
         name: Test Dummy
         description: Spawn a poor test dummy
@@ -986,7 +995,7 @@ spells:
         name: Petrify
         description: Immobilize your target
         cast: You petrify $target.
-        upgrade_description: "Increased duration"
+        upgrade_description: "Increased duration, decreased manacost"
     polymorph:
         name: Polymorph
         description: Turn your target into a sheep

--- a/Magic/src/main/resources/examples/survival/spells/harden.yml
+++ b/Magic/src/main/resources/examples/survival/spells/harden.yml
@@ -50,10 +50,10 @@ harden:
         size: 2
         destructible_override: true
         destructible: destructible,hardenable
-        brush: smooth_brick
+        brush: stone
         transparent: transparent_to_construction
         undo: 4000
-        cooldown: 1000
+        cooldown: 1500
         bypass_backfire: true
         select_self: false
         replace: true
@@ -62,7 +62,22 @@ harden:
 
 harden|2:
     parameters:
-        size: 3
+        undo: 5000
+        brush: stone_bricks
+
+harden|3:
+    parameters:
         undo: 6000
+        brush: smooth_stone
+
+harden|4:
+    parameters:
+        size: 3
+        undo: 7000
+        brush: polished_blackstone
+
+harden|5:
+    parameters:
+        undo: 8000
         brush: obsidian
 

--- a/Magic/src/main/resources/examples/survival/spells/meteor.yml
+++ b/Magic/src/main/resources/examples/survival/spells/meteor.yml
@@ -7,24 +7,62 @@ meteor:
     category: combat
     worth: 1500
     earns_sp: 5
+    upgrade_required_casts: 75
+    upgrade_required_path: master
     actions:
         cast:
         - class: ChangeContext
+          source_offset: 0,50,0
+          relative_source_offset: -15,0,0
           actions:
-          - class: Multiply
+          - class: CustomProjectile
+            tick_effects: big
+            projectile_effects: projectile_big
+            hit_effects: hit_big
+            spread: 0.1
+            range: 128
             actions:
-            - class: Delay
-            - class: CustomProjectile
+            - class: AreaOfEffect
+              radius: 16
+              y_radius: 16
               actions:
-              - class: AreaOfEffect
-                radius: 5
+              - class: Ignite
+              - class: Velocity
+                push: 3
+                velocity_max_distance: 24
+              - class: Damage
+                damage_multiplier: 5
+                damage_min_distance: 8
+                damage_max_distance: 24
+            - class: Sphere
+              radius: 10
+              actions:
+              - class: Skip
                 actions:
-                - class: Velocity
-                - class: Ignite
-                - class: Damage
-              -  class: Sphere
-                 actions:
-                 -  class: ModifyBlock
+                  - class: Delay
+              - class: ModifyBlock
+            tick:
+            - class: Skip
+              actions:
+                - class: Multiply
+                  actions:
+                  - class: ChangeContext
+                    source_at_target: true
+                    actions:
+                    - class: Asynchronous
+                      actions:
+                      - class: CustomProjectile
+                        gravity: 0.1
+                        range: 128
+                        actions:
+                          - class: AreaOfEffect
+                            actions:
+                              - class: Ignite
+                              - class: Velocity
+                              - class: Damage
+                          - class: Sphere
+                            actions:
+                              - class: ModifyBlock
     effects:
         cast:
         -  sound: ambient_nether_wastes_mood
@@ -37,6 +75,9 @@ meteor:
         -  class: EffectSingle
            custom_sound: magic.burn
            location: both
+        -  sound: entity_lightning_bolt_thunder
+           sound_pitch: 0.6
+           sound_volume: 1.8
         -  class: EffectSingle
            location: target
            target_offset: 0,.15,0
@@ -46,10 +87,44 @@ meteor:
              iterations: 5
              radius: 5
              particle: drip_lava
-        tick:
-        - particle: fireworks_spark
+        projectile:
+        - location: origin
+          effectlib:
+            class: Sphere
+            duration: $lifetime
+            radius: 0.1
+            particle: lava
+            particles: 8
+        projectile_big:
+        - location: origin
+          effectlib:
+            class: Sphere
+            duration: $lifetime
+            radius: 3
+            particle: lava
+            particles: 20
+            particle_count: 3
+            particle_offset_x: 0.5
+            particle_offset_y: 0.5
+            particle_offset_z: 0.5
+        big:
+        - particle: campfire_signal_smoke
           location: target
-          particle_count: 3
+          particle_count: 5
+          particle_data: 0.006
+          particle_offset_x: 0.5
+          particle_offset_y: 0.5
+          particle_offset_z: 0.5
+        - particle: smoke_large
+          location: target
+          particle_count: 15
+          particle_offset_x: 3
+          particle_offset_y: 3
+          particle_offset_z: 3
+        tick:
+        - particle: campfire_cosy_smoke
+          location: target
+          particle_count: 1
           particle_offset_x: 0.1
           particle_offset_y: 0.1
           particle_offset_z: 0.1
@@ -59,65 +134,93 @@ meteor:
           particle_offset_x: .7
           particle_offset_y: .7
           particle_offset_z: .7
-        projectile:
-        -  class: EffectSingle
-           location: origin
-           effectlib:
-             class: SphereEffect
-             particle: lava
-             iterations: 100
-             period: 3
-             particles: 4
-             particle_count: 2
-             particle_offset_x: 0.1
-             particle_offset_y: 0.1
-             particle_offset_z: 0.1
-             radius: 0.5
-        hit:
-        - class: EffectSingle
-          location: target
-          color: FE2E2E
-          firework: ball_large
-        - class: EffectSingle
+        hit_big:
+        - location: target
           sound: entity_generic_explode
-          sound_volume: 2
-          location: both
-        - class: EffectSingle
-          target_offset: 0,0.5,0
-          location: target
-          color: FE2E2E
-          firework: burst
+          sound_pitch: 0.3
+          sound_volume: 2.0
           particle: explosion_huge
+          particle_count: 3
+          particle_offset_x: 2.5
+          particle_offset_y: 2.5
+          particle_offset_z: 2.5
+        - location: target
+          sound: entity_firework_rocket_large_blast
+          sound_pitch: 0.7
+          sound_volume: 2.0
+          effectlib:
+            class: Modified
+            duration: 400
+            iterations: 8
+            parameters:
+              radius: 3 + 10*(t/i)
+            effect:
+              class: Sphere
+              particle: explosion_normal
+              particles: 25
+              particle_data: 0.1
+              particle_count: 2
+              particle_offset_x: 1.5
+              particle_offset_y: 1.5
+              particle_offset_z: 1.5
+        hit:
+        - location: target
+          sound: entity_generic_explode
+          sound_pitch: 0.6
+          sound_volume: 1.5
+          particle: explosion_large
+          particle_count: 3
+          particle_offset_x: 2.5
+          particle_offset_y: 2.5
+          particle_offset_z: 2.5
+        - location: target
+          sound: entity_firework_rocket_large_blast
+          sound_pitch: 1.0
+          sound_volume: 1.5
+          effectlib:
+            class: Modified
+            duration: 400
+            iterations: 8
+            parameters:
+              radius: 5*(t/i)
+            effect:
+              class: Sphere
+              particle: explosion_normal
+              particles: 5
+              particle_data: 0.1
+              particle_count: 2
+              particle_offset_x: 1.5
+              particle_offset_y: 1.5
+              particle_offset_z: 1.5
     parameters:
-        spread: 0.5
-        first:
-          spread: 0
-          delay: 0
+        multiply: 2
+        spread: 1.5
+        skip: 25
         radius: 3
-        delay: rand(0,2000)
-        multiply: rand(3,5)
-        target: other
-        item_speed: .5
-        living_entity_speed: .5
-        y_offset: 1
-        player_damage: 3
-        entity_damage: 3
+        y_radius: 4
+        push: 1
+        speed: 0.75
+        damage: 3
+        lifetime: 6000
         target_breakables: 1
-        range: 64
+        range: 32
         allow_max_range: true
-        hitbox: true
-        size: 1
-        velocity: 50
-        bypass_backfire: false
+        target_type: LivingEntity
+        target_self: true
+        delay: 50
         undo: 10000
+        duration: 5000
         cooldown: 45000
-        speed: 0.9
         falling: true
         brush: air
-        source_offset: 0,50,0
         direction: 0,0.75,0
         destructible: destructible,destructible2,destructible3
         destructible_override: true
         undo_speed: 2
     costs:
         mana: 200
+
+meteor|2:
+    parameters:
+        multiply: 3
+        cooldown: 30000

--- a/Magic/src/main/resources/examples/survival/spells/petrify.yml
+++ b/Magic/src/main/resources/examples/survival/spells/petrify.yml
@@ -71,26 +71,31 @@ petrify:
              duration: $duration
              radius: 1
     costs:
-        mana: 100
+        mana: 120
     parameters:
         velocity: 150
         range: 48
         target_type: LivingEntity
         target_breakables: 1
         target: other
-        duration: 3000
+        duration: 4000
         effect_slow: 20
         effect_jump: -20
         effect_weakness: 5
+        effect_slow_digging: 5
         protection_count: 1000
         hitbox: true
         cooldown: 10000
 
 petrify|2:
     parameters:
-      duration: 5000
+        duration: 6000
+    costs:
+        mana: 100
 
 petrify|3:
     parameters:
-      duration: 7000
+        duration: 8000
+    costs:
+        mana: 80
 

--- a/Magic/src/main/resources/examples/survival/spells/shuriken.yml
+++ b/Magic/src/main/resources/examples/survival/spells/shuriken.yml
@@ -1,6 +1,4 @@
 shuriken:
-    # This has been added automatically so that anything you remove here does not get inherited back in from the default configs
-    inherit: false
     icon: emerald{CustomModelData:18002}
     icon_disabled: emerald{CustomModelData:18003}
     legacy_icon: spell_icon:194
@@ -14,14 +12,16 @@ shuriken:
     actions:
         cast:
         -  class: CustomProjectile
-           actions:
-           -  class: ModifyNoDamageTicks
-           -  class: Damage
+           tick_size: 0.1
+           tick:
+           -  class: AreaOfEffect
+              actions:
+              -  class: Damage
     effects:
         tick:
         -  particle: block_crack
            material: iron_block
-           particle_count: 4
+           particle_count: 1
            particle_offset_x: 0.01
            particle_offset_y: 0.01
            particle_offset_z: 0.01
@@ -45,31 +45,37 @@ shuriken:
             sound: magic.bonk
             sound_volume: 0.2
         hit_entity:
-        -  sound: entity_arrow_hit
+        -  sound: entity_player_hurt_sweet_berry_bush
            sound_pitch: 1.6
     parameters:
+        target: block
+        target_self: true
+        target_self_timeout: 1500
         range: 32
-        target_type: Damageable
+        radius: 0.6
+        y_radius: 1.5
+        target_type: LivingEntity
         reflective: solid
         transparent: transparent
-        cooldown: 8000
+        cooldown: 10000
         velocity: 20
-        entity_hit_count: 3
         damage: 3
-        lifetime: 8000
-        hit_on_miss: true
+        lifetime: 5000
     costs:
-        mana: 80
+        mana: 120
 
 shuriken|2:
     upgrade_required_path: master
     upgrade_required_casts: 50
     parameters:
         lifetime: 10000
-        entity_hit_count: 5
+    costs:
+        mana: 100
 
 shuriken|3:
     parameters:
-        lifetime: 12000
-        entity_hit_count: 7
+        lifetime: 15000
+    costs:
+        mana: 80
+
 

--- a/Magic/src/main/resources/examples/survival/spells/silence.yml
+++ b/Magic/src/main/resources/examples/survival/spells/silence.yml
@@ -7,6 +7,8 @@ silence:
     category: dark
     worth: 750
     earns_sp: 10
+    upgrade_required_casts: 50
+    upgrade_required_path: master
     actions:
         cast:
         - class: CustomProjectile
@@ -56,13 +58,27 @@ silence:
              radius: 1
              particles: 20
     costs:
-        mana: 80
+        mana: 140
     parameters:
         range: 16
         cooldown: 20000
-        duration: 5000
+        duration: 6000
         target_type: LivingEntity
         target_breakables: 1
         target: other
         hitbox: true
+
+silence|2:
+    costs:
+        mana: 120
+    parameters:
+        cooldown: 18000
+        duration: 8000
+
+silence|3:
+    costs:
+        mana: 100
+    parameters:
+        cooldown: 16000
+        duration: 10000
 

--- a/Magic/src/main/resources/examples/survival/spells/sunstrike.yml
+++ b/Magic/src/main/resources/examples/survival/spells/sunstrike.yml
@@ -4,27 +4,31 @@ sunstrike:
   cast_on_no_target: false
   category: master
   pvp_restricted: true
+  upgrade_required_casts: 50
+  upgrade_required_path: master
   actions:
     cast:
      - class: CheckRequirements
-       requirements:
-        - time:
-            min: 0
-            max: 12000
        actions:
         - class: Delay
         - class: ChangeContext
-          source_at_target: true
+          source_is_target: true
           source_offset: 0,100,0
           actions:
             - class: CustomProjectile
               range: 255
+              target_self: true
               actions:
                 - class: AreaOfEffect
                   y_radius: 1
+                  target_self: true
                   actions:
                     - class: Damage
                     - class: Ignite
+       requirements:
+        - time:
+            min: 0
+            max: 12000
   effects:
     no_target: []
     tick:
@@ -58,23 +62,40 @@ sunstrike:
         class: Helix
         radius: $radius
         rotation: (t/i)*2
-        duration: 1000
-        iterations: 20
+        duration: 500
+        iterations: 10
       sound: magic.burn
   parameters:
-    target: other
+    target: block
     allow_max_range: true
     cooldown: 60000
     transparent: transparent_and_glass
     target_type: LivingEntity
-    target_self: true
     velocity: 500
     radius: 2
-    delay: 1500
+    delay: 2500
     range: 16
     duration: 5000
     damage_type: FIRE
-    damage: max(5,sin(3.14159*time/12000)*21)
+    damage: max(4,sin(3.14159*time/12000)*10)
   costs:
     mana: 100
+
+sunstrike|2:
+  upgrade_required_casts: 75
+  upgrade_required_path: master
+  parameters:
+    delay: 1500
+    damage: max(4,sin(3.14159*time/12000)*20)
+  costs:
+    mana: 150
+
+sunstrike|3:
+  upgrade_required_casts: 100
+  upgrade_required_path: master
+  parameters:
+    delay: 500
+    damage: max(4,sin(3.14159*time/12000)*40)
+  costs:
+    mana: 200
 

--- a/Magic/src/main/resources/examples/survival/spells/workbench.yml
+++ b/Magic/src/main/resources/examples/survival/spells/workbench.yml
@@ -9,6 +9,8 @@ workbench:
     quick_cast: true
     worth: 80
     show_undoable: false
+    upgrade_required_casts: 50
+    upgrade_required_path: apprentice
     actions:
         cast:
         - class: Inventory
@@ -27,7 +29,31 @@ workbench:
             particle_offset_y: 1
     parameters:
         target: none
-        cooldown: 5000
+        cooldown: 20000
         type: workbench
     costs:
-        mana: 30
+        mana: 80
+
+workbench|2:
+    upgrade_required_casts: 50
+    upgrade_required_path: student
+    parameters:
+        cooldown: 10000
+    costs:
+        mana: 40
+
+workbench|3:
+    upgrade_required_casts: 50
+    upgrade_required_path: student
+    parameters:
+        cooldown: 5000
+    costs:
+        mana: 20
+
+workbench|4:
+    upgrade_required_casts: 100
+    upgrade_required_path: master
+    parameters:
+        cooldown: 0
+    costs:
+        mana: 0


### PR DESCRIPTION
1) Rebalanced silence spell. Now has 3 levels:
Upgrade decreases manacost and cooldown, increases duration.

2) Sunstrike now has 3 levels:
Upgrade increases max damage(10/20/40), decreases delay.

3) Rework shuriken again:
Now uses this strange mechanic to target same entity multiple times.
Tried also ignore_hit_entities, but it causes strange behavior there projectile is "stuck" in the same entity, damaging him multiple times.

4) Rework meteor spell:
Now summons one big meteor, that shoots smaller meteors when flying. Big meteor deals 5x damage and breaks blocks in a 16 block radius.
Has 2 levels. Upgrade increases small meteor count, decreases cooldown.

5) Rebalance harden spell. Now has 5 levels:
Upgrade increases duration. Each level has different block type (stone/stone bricks/smooth stone/polished blackstone/obsidian).

6) Rebalance petrify:
Increased duration (4/6/8 seconds at each level), increased manacost (120,100,80 points at each level), added slow digging effect.

7) Workbench now has 4 levels:
Upgrade decreases cooldown(20,10,5,0 seconds at each level) and manacost(80,40,20,0 points at each level).