### PR TITLE
Refactor MagicLogger to store warning/errors, create new magic command /magic log (errors|warnings), and create Magic API log events

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicCommandExecutor.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicCommandExecutor.java
@@ -285,54 +285,29 @@ public class MagicCommandExecutor extends MagicMapExecutor {
 
             return true;
         }
-        if (subCommand.equalsIgnoreCase("errors") && controller instanceof MagicController) {
-
-            MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
-            List<LogMessage> errors = magicLogger.getErrors();
-
-            if (errors.isEmpty()) {
-                sender.sendMessage("There have been no errors since the config has loaded");
-                return true;
-            }
-
-            sender.sendMessage(ChatColor.AQUA + "There are " + errors.size() + "/50 errors from Magic:");
-            for (LogMessage logMessage : errors) {
-                sender.sendMessage(logMessage.getMessage());
-            }
-
-            return true;
-        }
-        if (subCommand.equalsIgnoreCase("warnings") && controller instanceof MagicController) {
-
-            MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
-            List<LogMessage> warnings = magicLogger.getWarnings();
-
-            if (warnings.isEmpty()) {
-                sender.sendMessage("There have been no warnings since the config has loaded");
-                return true;
-            }
-
-            sender.sendMessage(ChatColor.AQUA + "There are " + warnings.size() + "/50 warnings from Magic:");
-            for (LogMessage logMessage : warnings) {
-                sender.sendMessage(logMessage.getMessage());
-            }
-
-            return true;
-        }
         if (subCommand.equalsIgnoreCase("logs") && controller instanceof MagicController) {
 
             MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
 
             List<LogMessage> logs = new ArrayList<>();
-            logs.addAll(magicLogger.getWarnings());
-            logs.addAll(magicLogger.getErrors());
+            String type = args.length >= 2 ? args[1] : subCommand.toLowerCase();
+            if (type.equalsIgnoreCase("errors")) {
+                logs.addAll(magicLogger.getErrors());
+            }
+            else if (type.equalsIgnoreCase("warnings")) {
+                logs.addAll(magicLogger.getWarnings());
+            }
+            else {
+                logs.addAll(magicLogger.getErrors());
+                logs.addAll(magicLogger.getWarnings());
+            }
 
             if (logs.isEmpty()) {
                 sender.sendMessage("There have been no logs since the config has loaded");
                 return true;
             }
 
-            sender.sendMessage(ChatColor.AQUA + "There are " + logs.size() + " logs from Magic:");
+            sender.sendMessage(ChatColor.AQUA + "There are " + logs.size() + " " + type.toLowerCase() + " from Magic:");
             for (LogMessage logMessage : logs) {
                 sender.sendMessage(logMessage.getMessage());
             }

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicCommandExecutor.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicCommandExecutor.java
@@ -55,6 +55,8 @@ import com.elmakers.mine.bukkit.utility.BoundingBox;
 import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import com.elmakers.mine.bukkit.utility.DeprecatedUtils;
 import com.elmakers.mine.bukkit.utility.HitboxUtils;
+import com.elmakers.mine.bukkit.utility.LogMessage;
+import com.elmakers.mine.bukkit.utility.MagicLogger;
 import com.elmakers.mine.bukkit.utility.NMSUtils;
 import com.elmakers.mine.bukkit.utility.RunnableJob;
 import com.elmakers.mine.bukkit.wand.WandCleanupRunnable;
@@ -280,6 +282,60 @@ public class MagicCommandExecutor extends MagicMapExecutor {
             }
             runningTask = new WandCleanupRunnable(api, world, owner, check);
             runningTask.runTaskTimer(api.getPlugin(), 5, 5);
+
+            return true;
+        }
+        if (subCommand.equalsIgnoreCase("errors") && controller instanceof MagicController) {
+
+            MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
+            List<LogMessage> errors = magicLogger.getErrors();
+
+            if (errors.isEmpty()) {
+                sender.sendMessage("There have been no errors since the config has loaded");
+                return true;
+            }
+
+            sender.sendMessage(ChatColor.AQUA + "There are " + errors.size() + "/50 errors from Magic:");
+            for (LogMessage logMessage : errors) {
+                sender.sendMessage(logMessage.getMessage());
+            }
+
+            return true;
+        }
+        if (subCommand.equalsIgnoreCase("warnings") && controller instanceof MagicController) {
+
+            MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
+            List<LogMessage> warnings = magicLogger.getWarnings();
+
+            if (warnings.isEmpty()) {
+                sender.sendMessage("There have been no warnings since the config has loaded");
+                return true;
+            }
+
+            sender.sendMessage(ChatColor.AQUA + "There are " + warnings.size() + "/50 warnings from Magic:");
+            for (LogMessage logMessage : warnings) {
+                sender.sendMessage(logMessage.getMessage());
+            }
+
+            return true;
+        }
+        if (subCommand.equalsIgnoreCase("logs") && controller instanceof MagicController) {
+
+            MagicLogger magicLogger = ((MagicController) api.getController()).getLogger();
+
+            List<LogMessage> logs = new ArrayList<>();
+            logs.addAll(magicLogger.getWarnings());
+            logs.addAll(magicLogger.getErrors());
+
+            if (logs.isEmpty()) {
+                sender.sendMessage("There have been no logs since the config has loaded");
+                return true;
+            }
+
+            sender.sendMessage(ChatColor.AQUA + "There are " + logs.size() + " logs from Magic:");
+            for (LogMessage logMessage : logs) {
+                sender.sendMessage(logMessage.getMessage());
+            }
 
             return true;
         }

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/event/MagicErrorEvent.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/event/MagicErrorEvent.java
@@ -1,0 +1,51 @@
+package com.elmakers.mine.bukkit.api.event;
+
+import java.util.logging.LogRecord;
+import javax.annotation.Nullable;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * A custom event that the Magic plugin calls any time an error occurs
+ */
+public class MagicErrorEvent extends Event {
+    private final LogRecord logRecord;
+    private final String context;
+    private final int errorCount;
+    private final boolean isCaptured;
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public MagicErrorEvent(LogRecord logRecord, @Nullable String context, int errorCount, boolean isCaptured) {
+        this.logRecord = logRecord;
+        this.context = context;
+        this.errorCount = errorCount;
+        this.isCaptured = isCaptured;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public LogRecord getLogRecord() {
+        return logRecord;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public int getErrorCount() {
+        return errorCount;
+    }
+
+    public boolean isCaptured() {
+        return isCaptured;
+    }
+}

--- a/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/event/MagicWarningEvent.java
+++ b/MagicAPI/src/main/java/com/elmakers/mine/bukkit/api/event/MagicWarningEvent.java
@@ -1,0 +1,51 @@
+package com.elmakers.mine.bukkit.api.event;
+
+import java.util.logging.LogRecord;
+import javax.annotation.Nullable;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * A custom event that the Magic plugin calls any time a warning occurs
+ */
+public class MagicWarningEvent extends Event {
+    private final LogRecord logRecord;
+    private final String context;
+    private final int warningCount;
+    private final boolean isCaptured;
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public MagicWarningEvent(LogRecord logRecord, @Nullable String context, int warningCount, boolean isCaptured) {
+        this.logRecord = logRecord;
+        this.context = context;
+        this.warningCount = warningCount;
+        this.isCaptured = isCaptured;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public LogRecord getLogRecord() {
+        return logRecord;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public int getWarningCount() {
+        return warningCount;
+    }
+
+    public boolean isCaptured() {
+        return isCaptured;
+    }
+}


### PR DESCRIPTION
New log API events consist of:
- MagicErrorEvent
- MagicWarningEvent

MagicLogger now stores 50 errors and warnings at max, as well as calls the new API events. Additionally, the code was cleaned up a bit. With the new commands, it uses functions from the MagicLogger to display the logs for easy of use! Please let me know if anything needs to be improved or changed, and I can make the changes. Thank you!