### PR TITLE
Stop painting break if player is holding wand (optional)

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
@@ -484,6 +484,7 @@ public class MagicController implements MageController {
     private boolean bypassBuildPermissions = false;
     private boolean bypassBreakPermissions = false;
     private boolean bypassPvpPermissions = false;
+    private boolean wandsBreakingPainting = true;
     private boolean bypassFriendlyFire = false;
     private boolean useScoreboardTeams = false;
     private boolean defaultFriendly = true;
@@ -1247,6 +1248,10 @@ public class MagicController implements MageController {
             }
         }
         return allowed;
+    }
+
+    public boolean canWandsBreakPainting() {
+        return wandsBreakingPainting;
     }
 
     public void clearCache() {
@@ -7703,6 +7708,7 @@ public class MagicController implements MageController {
         bypassBuildPermissions = properties.getBoolean("bypass_build", bypassBuildPermissions);
         bypassBreakPermissions = properties.getBoolean("bypass_break", bypassBreakPermissions);
         bypassPvpPermissions = properties.getBoolean("bypass_pvp", bypassPvpPermissions);
+        wandsBreakingPainting = properties.getBoolean("can_wands_break_paintings", wandsBreakingPainting);
         bypassFriendlyFire = properties.getBoolean("bypass_friendly_fire", bypassFriendlyFire);
         useScoreboardTeams = properties.getBoolean("use_scoreboard_teams", useScoreboardTeams);
         defaultFriendly = properties.getBoolean("default_friendly", defaultFriendly);

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/BlockController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/listener/BlockController.java
@@ -16,6 +16,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -30,6 +31,7 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.event.world.WorldInitEvent;
@@ -446,6 +448,22 @@ public class BlockController implements Listener, ChunkLoadListener {
                     }
                 }
             }
+        }
+    }
+
+    @EventHandler
+    public void onPaintingBreak(HangingBreakByEntityEvent event) {
+        if (controller.canWandsBreakPainting() || !(event.getEntity() instanceof Painting) || !(event.getRemover() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getRemover();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        else if (controller.isWand(item)) {
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
I just want to point out that this is a completely optional setting which can be configured in config.yml. Also, none of this feature will run on default (the default is allowing it to break), it will have to be specified in the parameter. Basically what this will do is disallow paintings from breaking if you are holding a wand. It can be annoying, and so I decided to add a fix for it!

Example usage:
`can_wands_break_paintings: false`