### PR TITLE
Fix a NPE that can happen if the attribute is not a configuration section

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
@@ -2102,6 +2102,11 @@ public class MagicController implements MageController {
         attributes.clear();
         for (String key : keys) {
             logger.setContext("attribute." + key);
+            if (!attributeConfiguration.isConfigurationSection(key)) {
+                logger.warning("attribute." + key + " does not have the proper parameters. It will not be loaded.");
+                continue;
+            }
+
             MagicAttribute attribute = new MagicAttribute(key, attributeConfiguration.getConfigurationSection(key));
             attributes.put(key, attribute);
         }


### PR DESCRIPTION
If you were to put `test_attribute: 123` it would cause a NullPointerException. I made a quick fix for this.
