### PR TITLE
Fixed kill dealing less damage at higher levels

### DIFF
--- a/Magic/src/main/resources/examples/survival/spells/kill.yml
+++ b/Magic/src/main/resources/examples/survival/spells/kill.yml
@@ -121,7 +121,7 @@ kill|2:
     upgrade_required_casts: 50
     parameters:
         cooldown_mage: 8000
-        player_damage: 25
+        player_damage: 1000
         entity_damage: 35
         hitbox_size: 1.5
         velocity: 7
@@ -130,7 +130,7 @@ kill|2:
 kill|3:
     parameters:
         cooldown_mage: 5000
-        player_damage: 30
+        player_damage: 1000
         entity_damage: 40
         hitbox_size: 2
         velocity: 10


### PR DESCRIPTION
The kill spell deals less damage at higher levels. Specifically, its level one effect has "player_damage: 1000", but then the level two and level three effects have "player_damage:25" and "player_damage:30" in them, and both of those numbers are significantly less than 1000.

This should fix that. 

Also, the Kill spell only deals 30 (up to 40 with max level) damage against entities. I'm not sure if this is a bug or not, so I left it untouched, but it is something to look at.