### PR TITLE
Fix NPE caused by incorrect requirement check

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/requirements/MagicRequirement.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/requirements/MagicRequirement.java
@@ -373,7 +373,7 @@ public class MagicRequirement {
             }
         }
 
-        if (requiredTemplates != null && !requiredModifiers.isEmpty()) {
+        if (requiredTemplates != null && !requiredTemplates.isEmpty()) {
             String template = wand.getTemplateKey();
             if (template == null || !requiredTemplates.contains(template)) {
                 return false;


### PR DESCRIPTION
`requiredModifiers` was incorrectly being checked for emptiness in the checks for `requiredTemplates`. Since there is no null check for the modifiers list before isEmpty() is called, this throws an NPE when there is no `modifiers` key present in the config.
This part of the code exclusively handles checks `requiredTemplates` (the `wands` config node), so `requiredModifiers` doesn't have to be checked for emptiness here in the first place. This check should happen on `requiredTemplates` instead.

---

Received the following errors in-game and on console after attempting to add `wands:` requirement to Selector spell (no error with just `wand:`).
```yaml
  parameters:
    auto_close: true
    requirements:
    - wands: 
```
![image](https://user-images.githubusercontent.com/77467821/178847710-6d53bfb6-541c-4375-8812-16c8cf6623b8.png)

```
[22:35:33 ERROR]: [Magic]  There was an error checking spell offhandselector for issues
java.lang.NullPointerException: Cannot invoke "java.util.List.isEmpty()" because "this.requiredModifiers" is null
        at com.elmakers.mine.bukkit.requirements.MagicRequirement.checkRequirement(MagicRequirement.java:376) ~[?:?]
        at com.elmakers.mine.bukkit.requirements.RequirementsController.checkRequirement(RequirementsController.java:21) ~[?:?]
        at com.elmakers.mine.bukkit.magic.MagicController.checkRequirements(MagicController.java:7222) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction$SelectorConfiguration.checkRequirements(SelectorAction.java:581) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction$SelectorOption.updateIcon(SelectorAction.java:891) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction$SelectorOption.<init>(SelectorAction.java:800) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction.addOption(SelectorAction.java:1835) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction.loadOptions(SelectorAction.java:1872) ~[?:?]
        at com.elmakers.mine.bukkit.action.builtin.SelectorAction.prepare(SelectorAction.java:1793) ~[?:?]
        at com.elmakers.mine.bukkit.action.ActionContext.prepare(ActionContext.java:28) ~[?:?]
        at com.elmakers.mine.bukkit.action.ActionHandler.prepare(ActionHandler.java:132) ~[?:?]
        at com.elmakers.mine.bukkit.spell.ActionSpell.reloadParameters(ActionSpell.java:199) ~[?:?]
        at com.elmakers.mine.bukkit.tasks.ValidateSpellsTask.run(ValidateSpellsTask.java:47) ~[?:?]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.16.5.jar:git-Paper-788]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54) ~[patched_1.16.5.jar:git-Paper-788]
        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[patched_1.16.5.jar:git-Paper-788]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```
