### PR TITLE
Fix VelocityAction direction

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/VelocityAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/VelocityAction.java
@@ -106,8 +106,8 @@ public class VelocityAction extends BaseSpellAction
             Location to = entity.getLocation();
             Location from = context.getLocation();
 
-            Vector toVector = new Vector(to.getBlockX(), to.getBlockY(), to.getBlockZ());
-            Vector fromVector = new Vector(from.getBlockX(), from.getBlockY(), from.getBlockZ());
+            Vector toVector = new Vector(to.getX(), to.getY(), to.getZ());
+            Vector fromVector = new Vector(from.getX(), from.getY(), from.getZ());
 
             velocity = toVector;
             velocity.subtract(fromVector);


### PR DESCRIPTION
This fixes the VelocityAction direction not working as expected when both the source and the target are on the same block.

With the previous logic of using the block location, a source and target on the same block would have the same location, resulting in a velocity vector with a total length of 0. This would then fall back to the direction taken from the context, which results in unintended behavior for users.

Using the exact location fixes this, as different locations on the same block won't result in the same vector, and thus the subtraction of the two will still represent the direction from source to target.