### PR TITLE
Fix arena default win message mistake

### DIFF
--- a/Magic/src/main/resources/defaults/messages/arena.yml
+++ b/Magic/src/main/resources/defaults/messages/arena.yml
@@ -38,7 +38,7 @@ arena:
 
     win: |-
       &b$playerPath &6is the champion of &e$arena
-      &6with &4$hearts &6 hearts, and a total of &a$wins $6wins and &c$losses &6losses.
+      &6with &4$hearts &6hearts, and a total of &a$wins &6wins and &c$losses &6losses.
   stage:
     start_mobs: "t:$arena"
     win: "&aCongratulations!  &bYou have passed &3$arena"


### PR DESCRIPTION
Noticed a few mistakes in the default arena messages when testing during our update to `10.8.8`.

![magicchatPR](https://user-images.githubusercontent.com/77467821/235445757-72ee70bc-0d2e-42ef-9036-55d6e60cdabb.png)
* removed the extra space before `&6hearts`
* changed `$6wins` to `&6wins` so the text appears the correct colour
