### PR TITLE
Fix arena message replacement logic

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/arena/Arena.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/arena/Arena.java
@@ -281,9 +281,9 @@ public class Arena implements com.elmakers.mine.bukkit.api.arena.Arena {
     }
 
     public String convertPlayerMessage(String message, ArenaPlayer player) {
-        message = message.replace("$player", player.getName());
         message = message.replace("$playerDisplay", player.getDisplayName());
         message = message.replace("$playerPath", player.getNameAndPath());
+        message = message.replace("$player", player.getName());
 
         int winCount = player.getWins();
         int lostCount = player.getLosses();


### PR DESCRIPTION
The order in which arena message placeholders would get replaced was incorrect, causing the `$playerDisplay` and `$playerPath` placeholders to never get parsed correctly. Because `$player`would get replaced first, any occurences of the other two would become `MyCoolUsernameDisplay` and `MyCoolUserNamePath` and would no longer be recognized as the placeholders they were.

Simply replacing `$player` last fixes this.

### Before
![image](https://user-images.githubusercontent.com/25017989/235458008-3daf7327-c877-4abc-8b14-34b4b4e62d74.png)

### After
![image](https://user-images.githubusercontent.com/25017989/235458093-b2e49cc5-004f-4e50-81cf-fb5ce1aff913.png)
