### PR TITLE
Fixed missing dependency and NullPointerException 

### DIFF
--- a/Magic/pom.xml
+++ b/Magic/pom.xml
@@ -1258,7 +1258,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <minimizeJar>false</minimizeJar>
                     <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicGiveCommandExecutor.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/command/MagicGiveCommandExecutor.java
@@ -189,7 +189,9 @@ public class MagicGiveCommandExecutor extends MagicTabExecutor {
                 addIfPermissible(sender, options, "magic.create.", "egg:" + mobKey);
             }
             for (PotionEffectType effectType : PotionEffectType.values()) {
-                addIfPermissible(sender, options, "magic.create.", "potion:" + effectType.getName().toLowerCase());
+                if (effectType != null) {
+                    addIfPermissible(sender, options, "magic.create.", "potion:" + effectType.getName().toLowerCase());
+                }
             }
             addIfPermissible(sender, options, "magic.create.", "recipe:*");
             addIfPermissible(sender, options, "magic.create.", "recipes:*");


### PR DESCRIPTION
Heya! :D
How are you?
A little bit more details:
1) The maven-shade-plugin dependency was 3.3.0-SNAPSHOT which is no longer available so I updated it to 3.3.0.
2) There was a NullPointerException on the mgive command on some versions such as 1.12.2 since the effect type on the 0 index in the potion effect types was null.