### PR TITLE
Fixed the legacy player heads wands bug that caused them to only have one texture

### DIFF
--- a/CompatibilityLib/base/src/main/java/com/elmakers/mine/bukkit/utility/platform/base/InventoryUtilsBase.java
+++ b/CompatibilityLib/base/src/main/java/com/elmakers/mine/bukkit/utility/platform/base/InventoryUtilsBase.java
@@ -195,8 +195,8 @@ public abstract class InventoryUtilsBase implements InventoryUtils {
     @Override
     public ItemStack setSkullURL(ItemStack itemStack, String url) {
         try {
-            // Using a fixed non-random UUID here so skulls of the same type can stack
-            return setSkullURL(itemStack, new URL(url), CompatibilityConstants.SKULL_UUID);
+            // Using a deterministic non-random UUID derived from the skull url here so skulls of the same type can stack
+            return setSkullURL(itemStack, new URL(url), UUID.nameUUIDFromBytes(url.getBytes()));
         } catch (MalformedURLException e) {
             platform.getLogger().log(Level.WARNING, "Malformed URL: " + url, e);
         }

--- a/CompatibilityLib/common/src/main/java/com/elmakers/mine/bukkit/utility/CompatibilityConstants.java
+++ b/CompatibilityLib/common/src/main/java/com/elmakers/mine/bukkit/utility/CompatibilityConstants.java
@@ -1,7 +1,5 @@
 package com.elmakers.mine.bukkit.utility;
 
-import java.util.UUID;
-
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 
@@ -15,7 +13,6 @@ public class CompatibilityConstants {
     public static final int NBT_TYPE_DOUBLE = 6;
     public static final int NBT_TYPE_STRING = 8;
     public static final int FIREWORK_TYPE = 76;
-    public static final UUID SKULL_UUID = UUID.fromString("3f599490-ca3e-49b5-8e75-78181ebf4232");
 
     public static String LORE_WRAP_PREFIX = " ";
     public static int MAX_LORE_LENGTH = 24;

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
@@ -6861,7 +6861,7 @@ public class MagicController implements MageController, ChunkLoadListener {
     @Nonnull
     public ItemStack getURLSkull(String url) {
         try {
-            ItemStack stack = getURLSkull(new URL(url), CompatibilityConstants.SKULL_UUID);
+            ItemStack stack = getURLSkull(new URL(url), UUID.nameUUIDFromBytes(url.getBytes()));
             return stack == null ? new ItemStack(Material.AIR) : stack;
         } catch (MalformedURLException e) {
             Bukkit.getLogger().log(Level.WARNING, "Malformed URL: " + url, e);


### PR DESCRIPTION
There was a bug in the legacy versions (at least checked on 1.12.2) which wands with a textured skull icon would have bugged to all have the same texture, this happened since the UUID used for the heads was the same.
I fixed it by changing the UUID to be deterministic derived from the URL. 