### PR TITLE
add LineOfEffect, random choose parameter for AreaOfEffect

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/AreaOfEffectAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/AreaOfEffectAction.java
@@ -96,7 +96,20 @@ public class AreaOfEffectAction extends CompoundEntityAction
         if (targetCount > 0)
         {
             if (randomChoose) {
-                List<Entity> candidatesList = new ArrayList<>(candidates);
+                List<Entity> candidatesList = new ArrayList<>();
+                for (Entity entity : candidates) {
+                    boolean canTarget = entity != targetEntity || targetSource;
+                    if (ignore != null && ignore.contains(entity.getUniqueId())) {
+                        mage.sendDebugMessage(ChatColor.DARK_RED + "Ignoring Modified Target " + ChatColor.GREEN + entity.getType(), 16);
+                        continue;
+                    }
+                    if (canTarget && context.canTarget(entity)) {
+                        candidatesList.add(entity);
+                        mage.sendDebugMessage(ChatColor.DARK_GREEN + "Target " + ChatColor.GREEN + entity.getType(), 12);
+                    } else if (mage.getDebugLevel() > 7) {
+                        mage.sendDebugMessage(ChatColor.DARK_RED + "Skipped Target " + ChatColor.GREEN + entity.getType(), 16);
+                    }
+                }
                 Collections.shuffle(candidatesList);
                 for (int i = 0; i < targetCount && i < candidatesList.size(); i++) {
                     entities.add(new WeakReference<>(candidatesList.get(i)));

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/LineOfEffectAction.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/action/builtin/LineOfEffectAction.java
@@ -93,7 +93,20 @@ public class LineOfEffectAction extends CompoundEntityAction {
         Entity targetEntity = context.getTargetEntity();
         if (targetCount > 0) {
             if (randomChoose) {
-                List<Entity> candidatesList = new ArrayList<>(candidates);
+                List<Entity> candidatesList = new ArrayList<>();
+                for (Entity entity : candidates) {
+                    boolean canTarget = entity != targetEntity || targetSource;
+                    if (ignore != null && ignore.contains(entity.getUniqueId())) {
+                        mage.sendDebugMessage(ChatColor.DARK_RED + "Ignoring Modified Target " + ChatColor.GREEN + entity.getType(), 16);
+                        continue;
+                    }
+                    if (canTarget && context.canTarget(entity)) {
+                        candidatesList.add(entity);
+                        mage.sendDebugMessage(ChatColor.DARK_GREEN + "Target " + ChatColor.GREEN + entity.getType(), 12);
+                    } else if (mage.getDebugLevel() > 7) {
+                        mage.sendDebugMessage(ChatColor.DARK_RED + "Skipped Target " + ChatColor.GREEN + entity.getType(), 16);
+                    }
+                }
                 Collections.shuffle(candidatesList);
                 for (int i = 0; i < targetCount && i < candidatesList.size(); i++) {
                     entities.add(new WeakReference<>(candidatesList.get(i)));


### PR DESCRIPTION
LineOfEffect provides a new targeting method which target entities along the view direction, all entities in the cylinder(with height=rangeFront-rangeBack, radius=radius) will be targeted. I copied code from AreaOfEffectAction to implement this, and noticed that the process of 'target_count' may need extra review, because I don't really understand it.

Also added a new parameter 'random_choose' for AreaOfEffect and LineOfEffect, allowing the action to choose randomly, instead of calculating scores and select the best.