### PR TITLE
Add pale oak and (rest of) mangrove to materials files

### DIFF
--- a/Magic/src/main/resources/defaults/materials/all_leaves.yml
+++ b/Magic/src/main/resources/defaults/materials/all_leaves.yml
@@ -18,3 +18,6 @@ all_leaves:
 
 # 1.20
 - cherry_leaves
+
+# 1.21.4
+- pale_oak_leaves

--- a/Magic/src/main/resources/defaults/materials/logs.yml
+++ b/Magic/src/main/resources/defaults/materials/logs.yml
@@ -33,3 +33,7 @@ logs:
 - cherry_wood
 - stripped_cherry_log
 - stripped_cherry_wood
+- pale_oak_log
+- pale_oak_wood
+- stripped_pale_oak_log
+- stripped_pale_oak_wood

--- a/Magic/src/main/resources/defaults/materials/saplings.yml
+++ b/Magic/src/main/resources/defaults/materials/saplings.yml
@@ -17,3 +17,6 @@ saplings:
 
 # 1.20
 - cherry_sapling
+
+# 1.21.4
+- pale_oak_sapling

--- a/Magic/src/main/resources/defaults/materials/saplings.yml
+++ b/Magic/src/main/resources/defaults/materials/saplings.yml
@@ -13,7 +13,8 @@ saplings:
 - azalea
 - flowering_azalea
 
-# 1.19 - should mangrove_propagule (or .. something?) be in here?
+# 1.19
+- mangrove_propagule
 
 # 1.20
 - cherry_sapling

--- a/Magic/src/main/resources/defaults/materials/trees.yml
+++ b/Magic/src/main/resources/defaults/materials/trees.yml
@@ -5,3 +5,4 @@ trees:
 - wart_blocks
 - vine
 - cocoa
+- mangrove_roots


### PR DESCRIPTION
Added the new Pale Oak logs, leaves, and sapling to the default materials files.

Also, added the mangrove roots and mangrove propagule.

I tested the changes in a local server with the .yaml files added in the config, and it worked.