### PR TITLE
add Multiverse 5 integration

### DIFF
--- a/Magic/pom.xml
+++ b/Magic/pom.xml
@@ -240,6 +240,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.mvplugins.multiverse.core</groupId>
+            <artifactId>multiverse-core</artifactId>
+            <version>5.3.0</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.mewin</groupId>
             <artifactId>WGCustomFlags</artifactId>
             <version>1.6.1</version>

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/magic/MagicController.java
@@ -219,6 +219,7 @@ import com.elmakers.mine.bukkit.protection.FactionsManager;
 import com.elmakers.mine.bukkit.protection.GriefPreventionManager;
 import com.elmakers.mine.bukkit.protection.LandsManager;
 import com.elmakers.mine.bukkit.protection.LocketteManager;
+import com.elmakers.mine.bukkit.protection.Multiverse5Manager;
 import com.elmakers.mine.bukkit.protection.MultiverseManager;
 import com.elmakers.mine.bukkit.protection.NCPManager;
 import com.elmakers.mine.bukkit.protection.PreciousStonesManager;
@@ -394,6 +395,7 @@ public class MagicController implements MageController, ChunkLoadListener {
     private final WorldGuardManager worldGuardManager = new WorldGuardManager();
     private final PvPManagerManager pvpManager = new PvPManagerManager();
     private final MultiverseManager multiverseManager = new MultiverseManager();
+    private final Multiverse5Manager multiverse5Manager = new Multiverse5Manager();
     private final PreciousStonesManager preciousStonesManager = new PreciousStonesManager();
     private final TownyManager townyManager = new TownyManager();
     private final GriefPreventionManager griefPreventionManager = new GriefPreventionManager();
@@ -1649,7 +1651,7 @@ public class MagicController implements MageController, ChunkLoadListener {
                             valueMap.put("Citizens", controller.citizens != null ? 1 : 0);
                             valueMap.put("CommandBook", controller.hasCommandBook ? 1 : 0);
                             valueMap.put("PvpManager", controller.pvpManager.isEnabled() ? 1 : 0);
-                            valueMap.put("Multiverse-Core", controller.multiverseManager.isEnabled() ? 1 : 0);
+                            valueMap.put("Multiverse-Core", controller.multiverseManager.isEnabled() || controller.multiverse5Manager.isEnabled() ? 1 : 0);
                             valueMap.put("Towny", controller.townyManager.isEnabled() ? 1 : 0);
                             valueMap.put("GriefPrevention", controller.griefPreventionManager.isEnabled() ? 1 : 0);
                             valueMap.put("PreciousStones", controller.preciousStonesManager.isEnabled() ? 1 : 0);
@@ -2191,6 +2193,7 @@ public class MagicController implements MageController, ChunkLoadListener {
         if (worldGuardManager.isEnabled()) pvpManagers.add(worldGuardManager);
         if (pvpManager.isEnabled()) pvpManagers.add(pvpManager);
         if (multiverseManager.isEnabled()) pvpManagers.add(multiverseManager);
+        if (multiverse5Manager.isEnabled()) pvpManagers.add(multiverse5Manager);
         if (preciousStonesManager.isEnabled()) pvpManagers.add(preciousStonesManager);
         if (townyManager.isEnabled()) pvpManagers.add(townyManager);
         if (griefPreventionManager.isEnabled()) pvpManagers.add(griefPreventionManager);
@@ -8099,6 +8102,7 @@ public class MagicController implements MageController, ChunkLoadListener {
 
         // Link to Multiverse
         multiverseManager.initialize(plugin);
+        multiverse5Manager.initialize(plugin);
 
         // Link to DeadSouls
         Plugin deadSoulsPlugin = plugin.getServer().getPluginManager().getPlugin("DeadSouls");
@@ -8629,6 +8633,7 @@ public class MagicController implements MageController, ChunkLoadListener {
         factionsManager.setEnabled(properties.getBoolean("factions_enabled", factionsManager.isEnabled()));
         pvpManager.setEnabled(properties.getBoolean("pvp_manager_enabled", pvpManager.isEnabled()));
         multiverseManager.setEnabled(properties.getBoolean("multiverse_enabled", multiverseManager.isEnabled()));
+        multiverse5Manager.setEnabled(properties.getBoolean("multiverse_enabled", multiverse5Manager.isEnabled()));
         preciousStonesManager.setEnabled(properties.getBoolean("precious_stones_enabled", preciousStonesManager.isEnabled()));
         preciousStonesManager.setOverride(properties.getBoolean("precious_stones_override", true));
         townyManager.setEnabled(properties.getBoolean("towny_enabled", townyManager.isEnabled()));

--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/Multiverse5Manager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/Multiverse5Manager.java
@@ -1,0 +1,58 @@
+package com.elmakers.mine.bukkit.protection;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.mvplugins.multiverse.core.MultiverseCore;
+import org.mvplugins.multiverse.core.MultiverseCoreApi;
+import org.mvplugins.multiverse.core.world.MultiverseWorld;
+import org.mvplugins.multiverse.core.world.WorldManager;
+import org.mvplugins.multiverse.external.vavr.control.Option;
+
+import com.elmakers.mine.bukkit.api.protection.PVPManager;
+
+public class Multiverse5Manager implements PVPManager {
+    private boolean enabled = false;
+    private MultiverseCore mv = null;
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled && mv != null;
+    }
+
+    public void initialize(Plugin plugin) {
+        if (enabled) {
+            try {
+                Plugin mvPlugin = plugin.getServer().getPluginManager().getPlugin("Multiverse-Core");
+                if (mvPlugin instanceof MultiverseCore) {
+                    mv = (MultiverseCore) mvPlugin;
+                }
+            } catch (Throwable ignored) {
+            }
+
+            if (mv != null) {
+                plugin.getLogger().info("Multiverse-Core found, will respect PVP settings");
+            }
+        } else {
+            mv = null;
+        }
+    }
+
+    @Override
+    public boolean isPVPAllowed(Player player, Location location) {
+        if (!enabled || mv == null || location == null) return true;
+        World world = location.getWorld();
+        if (world == null) return true;
+        MultiverseCoreApi api = MultiverseCoreApi.get();
+        WorldManager worldManager = api.getWorldManager();
+        if (worldManager == null) return true;
+        Option<MultiverseWorld> mvWorldOption = worldManager.getWorld(world);
+        if (mvWorldOption.isEmpty()) return true;
+        MultiverseWorld mvWorld = mvWorldOption.get();
+        return mvWorld.getPvp();
+    }
+}


### PR DESCRIPTION
Old integration with multiverse 4.x is no longer valid for multiverse 5.x, to keep compatibility with old versions, a new Multiverse5Manager is introduced while keeping the existing MultiverseManager.

Tested with Multiverse 5.3.0, acting as a PvP Manager.

Also note that I encountered a build issue with zAuctionHouseV3-API, as version `4.0.4.9` doesn't exist.
```
<dependency>
    <groupId>com.github.Maxlego08</groupId>
    <artifactId>zAuctionHouseV3-API</artifactId>
    <version>4.0.4.9</version>
    <scope>provided</scope>
</dependency>
```
For a successful build, I changed the version to `3.2.1.9`, this change is not included in this commit.