### PR TITLE
fix(lands): handle null and offline players in permission checks

### DIFF
--- a/Magic/src/main/java/com/elmakers/mine/bukkit/protection/LandsManager.java
+++ b/Magic/src/main/java/com/elmakers/mine/bukkit/protection/LandsManager.java
@@ -41,14 +41,25 @@ public class LandsManager implements PVPManager, BlockBreakManager, BlockBuildMa
     }
 
     protected boolean hasPermission(Player player, Location location, RoleFlag flag, boolean sendMessage) {
-        LandWorld landWorld = lands.getWorld(player.getWorld());
-        LandPlayer landPlayer = lands.getLandPlayer(player.getUniqueId());
-
-        if (landWorld != null) {
-            return landWorld.hasRoleFlag(landPlayer, location, flag, null, sendMessage);
+        if (player == null) {
+            return true;
         }
 
-        return true;
+        LandPlayer landPlayer = lands.getLandPlayer(player.getUniqueId());
+        LandWorld landWorld = lands.getWorld(player.getWorld());
+
+        // If the world has not enabled the claiming feature
+        if (landWorld == null) {
+            return true;
+        }
+
+        if (landPlayer != null) {
+            // If the player is online, check if the player has bypassed permissions.
+            return landWorld.hasRoleFlag(landPlayer, location, flag, null, sendMessage);
+        } else {
+            // If the player is offline, it does not check whether the player has bypassed permissions.
+            return landWorld.hasRoleFlag(player.getUniqueId(), location, flag);
+        }
     }
 
     @Override
@@ -93,9 +104,9 @@ public class LandsManager implements PVPManager, BlockBreakManager, BlockBuildMa
             Player sourcePlayer = (Player) source;
 
             if (target instanceof Monster) {
-                return hasPermission(sourcePlayer, target.getLocation(), Flags.ATTACK_MONSTER, true);
+                return hasPermission(sourcePlayer, target.getLocation(), Flags.ATTACK_MONSTER, false);
             } else if (target instanceof Animals) {
-                return hasPermission(sourcePlayer, target.getLocation(), Flags.ATTACK_ANIMAL, true);
+                return hasPermission(sourcePlayer, target.getLocation(), Flags.ATTACK_ANIMAL, false);
             } else {
                 return hasPermission(sourcePlayer, target.getLocation(), Flags.INTERACT_GENERAL, false);
             }
@@ -110,6 +121,9 @@ public class LandsManager implements PVPManager, BlockBreakManager, BlockBuildMa
     @Override
     public Collection<PlayerWarp> getWarps(@Nonnull Player player) {
         LandPlayer landPlayer = lands.getLandPlayer(player.getUniqueId());
+        if (landPlayer == null) {
+            return null;
+        }
 
         Collection<? extends Land> joinedLands = landPlayer.getLands();
 
@@ -119,7 +133,9 @@ public class LandsManager implements PVPManager, BlockBreakManager, BlockBuildMa
         Collection<PlayerWarp> warps = new ArrayList<>();
         for (Land joinedLand : joinedLands) {
             Location location = joinedLand.getSpawn();
-            if (location != null) {
+            if (location != null &&
+                    hasPermission(player, location, Flags.SPAWN_TELEPORT, false) &&
+                    hasPermission(player, location, Flags.LAND_ENTER, false)) {
                 PlayerWarp warp = new PlayerWarp(joinedLand.getName(), location);
                 warps.add(warp);
             }


### PR DESCRIPTION
Fix errors when spells are cast by non-player entities, such as mobs spawned with `/mmob spawn warlock`, by safely handling null player contexts during Lands permission checks.

```
[11:29:13] [Server thread/WARN]: [Magic]  Something is going wrong with Lands build checks
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.getWorld()" because "player" is null
	at Magic-11.0.jar//com.elmakers.mine.bukkit.protection.LandsManager.hasPermission(LandsManager.java:44) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.protection.LandsManager.hasBuildPermission(LandsManager.java:68) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.MagicController.hasBuildPermission(MagicController.java:1301) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.Mage.hasBuildPermission(Mage.java:2753) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.hasBuildPermission(BaseSpell.java:1774) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.canContinue(BaseSpell.java:1711) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.canCast(BaseSpell.java:1661) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.prepareCast(BaseSpell.java:1425) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1478) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1474) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1464) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.CustomTrigger.cast(CustomTrigger.java:149) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.MobTrigger.cast(MobTrigger.java:37) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.CustomTrigger.execute(CustomTrigger.java:183) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.entity.EntityMageData.tick(EntityMageData.java:203) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.entity.EntityData.tick(EntityData.java:1464) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.Mage.tick(Mage.java:1947) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.tasks.MageUpdateTask.run(MageUpdateTask.java:33) ~[?:?]
	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1802) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1655) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:449) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1713) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1383) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```

```
[11:29:13] [Server thread/WARN]: [Magic]  Something is going wrong with Lands pvp checks
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.getWorld()" because "player" is null
	at Magic-11.0.jar//com.elmakers.mine.bukkit.protection.LandsManager.hasPermission(LandsManager.java:44) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.protection.LandsManager.isPVPAllowed(LandsManager.java:57) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.MagicController.isPVPAllowed(MagicController.java:1340) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.Mage.isPVPAllowed(Mage.java:2748) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.canContinue(BaseSpell.java:1720) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.canCast(BaseSpell.java:1661) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.prepareCast(BaseSpell.java:1425) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1478) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1474) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.spell.BaseSpell.cast(BaseSpell.java:1464) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.CustomTrigger.cast(CustomTrigger.java:149) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.MobTrigger.cast(MobTrigger.java:37) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.CustomTrigger.execute(CustomTrigger.java:183) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.entity.EntityMageData.tick(EntityMageData.java:203) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.entity.EntityData.tick(EntityData.java:1464) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.magic.Mage.tick(Mage.java:1947) ~[?:?]
	at Magic-11.0.jar//com.elmakers.mine.bukkit.tasks.MageUpdateTask.run(MageUpdateTask.java:33) ~[?:?]
	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1802) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1655) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:449) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1713) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1383) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304) ~[paper-26.1.2.jar:26.1.2-64-2186e1e]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```