### PR TITLE
Preserve hex colors in action bar messages

### DIFF
--- a/CompatibilityLib/common/src/main/java/com/elmakers/mine/bukkit/utility/spigot/SpigotUtils.java
+++ b/CompatibilityLib/common/src/main/java/com/elmakers/mine/bukkit/utility/spigot/SpigotUtils.java
@@ -43,7 +43,7 @@ public class SpigotUtils implements com.elmakers.mine.bukkit.utility.platform.Sp
         if (ChatUtils.hasJSON(message)) {
             player.spigot().sendMessage(ChatMessageType.ACTION_BAR, parseChatComponents(message));
         } else {
-            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(message));
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, fromLegacyText(message));
         }
         return true;
     }
@@ -54,7 +54,7 @@ public class SpigotUtils implements com.elmakers.mine.bukkit.utility.platform.Sp
         if (ChatUtils.hasJSON(message)) {
             components = parseChatComponents(message);
         } else {
-            components = new BaseComponent[]{new TextComponent(message)};
+            components = fromLegacyText(message);
         }
         BaseComponent[] fontComponent = new ComponentBuilder("").font(font).append(components).create();
         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, fontComponent);


### PR DESCRIPTION
## Summary

Action bar messages now render hex (`&#rrggbb` / `§x§r§r§g§g§b§b`) colors and legacy color codes, matching how the same text already renders in chat and boss bars.

In `SpigotUtils.sendActionBar`, the non-JSON branch wrapped the message in a bare `new TextComponent(message)`. A plain `TextComponent` stores the literal string and does not parse `§`/`§x` sequences into colored child components, so hex escapes leaked through to the action bar unrendered. Both the base overload and the `font` overload had this issue.

This routes the non-JSON action bar text through the existing hex-aware `fromLegacyText(...)` parser (the same one `parseChatComponents` already uses for chat), which converts `§x§r§r§g§g§b§b` into `ChatColor.of("#rrggbb")`. The JSON branches are untouched. `fromLegacyText` already returns `BaseComponent[]`, matching both the `sendMessage(ChatMessageType, BaseComponent...)` signature and the `ComponentBuilder.append(BaseComponent[])` call, so no signature changes were needed.

## Why this matters

Hex colors render correctly in chat but not on the action bar, a regression noted since v10.8.13 and still present in v10.10.5. This makes action bar text the only surface that drops hex colors, producing stray characters instead of the intended color.

https://github.com/elBukkit/MagicPlugin/issues/1479

## Testing

- `mvn -pl CompatibilityLib/common -am compile`: BUILD SUCCESS, 0 Checkstyle violations. Forced a clean recompile of the changed file to confirm it builds (warnings present are pre-existing in `fromLegacyText`, none on the changed lines).
- Verified the change mirrors the existing non-JSON handling in `parseChatComponents` (line 225) and `serializeBossBar`, so action bar, chat, and boss bar now treat legacy/hex text consistently.

Fixes #1479
